### PR TITLE
Make passive mode truly passive when set via SyntasticToggleMode

### DIFF
--- a/plugin/syntastic/modemap.vim
+++ b/plugin/syntastic/modemap.vim
@@ -57,6 +57,7 @@ function! g:SyntasticModeMap.toggleMode() abort " {{{2
 
     if self._mode ==# 'active'
         let self._mode = 'passive'
+        let self._activeFiletypes = []
     else
         let self._mode = 'active'
     endif
@@ -77,7 +78,6 @@ function! g:SyntasticModeMap.modeInfo(filetypes) abort " {{{2
     let type = len(a:filetypes) ? a:filetypes[0] : &filetype
     echomsg 'Info for filetype: ' . type
 
-    call self.synch()
     echomsg 'Global mode: ' . self._mode
     if self._mode ==# 'active'
         if len(self._passiveFiletypes)


### PR DESCRIPTION
Currently, if a filetype is marked active in g:syntastic_mode_map via active_filetypes,
switching to passive mode via SyntasticToggleMode will continue to make all buffers
whose filetypes were included in active_filetypes active.

The behavior I expected is that a switch to passive mode via SyntasticToggleMode
at runtime should override the starting configuration via g:syntastic_mode_map.

The current patch does just that.
