### PR TITLE
Vala: add support for additional source files

### DIFF
--- a/doc/syntastic-checkers.txt
+++ b/doc/syntastic-checkers.txt
@@ -6499,6 +6499,12 @@ Default: unset
 Space-separated list of "source" files to be passed to the compiler, the
 extension ".vala" is automatically appended.
 
+                                                *'g:syntastic_vala_flags'*
+Type: string or array of strings
+Default: unset
+Space-separated list of flags to be passed to the compiler. The leading "--"
+are prepended automatically.
+
 Notes~
 
 If |'g:syntastic_vala_modules'| is unset, you can also specify a list of

--- a/doc/syntastic-checkers.txt
+++ b/doc/syntastic-checkers.txt
@@ -6493,6 +6493,12 @@ Default: unset
 Space-separated list of "vapi" directories to be passed as "--vapidirs"
 arguments.
 
+                                                *'g:syntastic_vala_sources'*
+Type: string or array of strings
+Default: unset
+Space-separated list of "source" files to be passed to the compiler, the
+extension ".vala" is automatically appended.
+
 Notes~
 
 If |'g:syntastic_vala_modules'| is unset, you can also specify a list of
@@ -6501,7 +6507,11 @@ module to load for the current file by adding a special comment starting with
 
 If |'g:syntastic_vala_vapi_dirs'| is unset, you can also specify a list of
 "vapi" directories for the current file by adding a special comment starting
-with "// vapidirs:" and containing a space-delimited list of names.
+with "// vapidirs: " and containing a space-delimited list of names.
+
+If |'g:syntastic_vala_sources'| is unset, you can also specify a list of
+"source" files needed by the current file by adding a special comment starting
+with "// sources: " and containing a space-delimited list of names.
 
 ==============================================================================
 SYNTAX CHECKERS FOR VERILOG                       *syntastic-checkers-verilog*

--- a/syntax_checkers/vala/valac.vim
+++ b/syntax_checkers/vala/valac.vim
@@ -27,7 +27,8 @@ function! SyntaxCheckers_vala_valac_GetLocList() dict " {{{1
     let vala_pkg_args = join(map(s:GetValaModules(), '"--pkg ".v:val'), ' ')
     let vala_vapi_args = join(map(s:GetValaVapiDirs(), '"--vapidir ".v:val'), ' ')
     let vala_src_args = join(map(s:GetValaSources(), 'v:val.".vala"'), ' ')
-    let makeprg = self.makeprgBuild({ 'args': '-C ' . vala_src_args . ' ' . vala_pkg_args . ' ' . vala_vapi_args })
+    let vala_flag_args = join(map(s:GetValaFlags(), '"--".v:val'), ' ')
+    let makeprg = self.makeprgBuild({ 'args': '-C ' . vala_flag_args . ' ' . vala_src_args . ' ' . vala_pkg_args . ' ' . vala_vapi_args })
 
     let errorformat =
         \ '%A%f:%l.%c-%\d%\+.%\d%\+: %t%[a-z]%\+: %m,'.
@@ -90,6 +91,23 @@ function! s:GetValaSources() " {{{2
     let sources_line = search('^// sources: ', 'n')
     let sources_str = getline(sources_line)
     return split(strpart(sources_str, 12), '\m\s\+')
+endfunction " }}}2
+
+function! s:GetValaFlags() " {{{2
+    if exists('g:syntastic_vala_flags') || exists('b:syntastic_vala_flags')
+        let flags = syntastic#util#var('vala_flags')
+        if type(flags) == type('')
+            return split(flags, '\m\s\+')
+        elseif type(flags) == type([])
+            return copy(flags)
+        else
+            echoerr 'syntastic_vala_flags must be either a list, or a string: fallback to in-file modules string'
+        endif
+    endif
+
+    let flags = search('^// flags: ', 'n')
+    let flags = getline(flags)
+    return split(strpart(flags, 10), '\m\s\+')
 endfunction " }}}2
 
 " }}}1

--- a/syntax_checkers/vala/valac.vim
+++ b/syntax_checkers/vala/valac.vim
@@ -26,7 +26,8 @@ endfunction " }}}1
 function! SyntaxCheckers_vala_valac_GetLocList() dict " {{{1
     let vala_pkg_args = join(map(s:GetValaModules(), '"--pkg ".v:val'), ' ')
     let vala_vapi_args = join(map(s:GetValaVapiDirs(), '"--vapidir ".v:val'), ' ')
-    let makeprg = self.makeprgBuild({ 'args': '-C ' . vala_pkg_args . ' ' . vala_vapi_args })
+    let vala_src_args = join(map(s:GetValaSources(), 'v:val.".vala"'), ' ')
+    let makeprg = self.makeprgBuild({ 'args': '-C ' . vala_src_args . ' ' . vala_pkg_args . ' ' . vala_vapi_args })
 
     let errorformat =
         \ '%A%f:%l.%c-%\d%\+.%\d%\+: %t%[a-z]%\+: %m,'.
@@ -72,6 +73,23 @@ function! s:GetValaVapiDirs() " {{{2
     let vapi_line = search('^//\s*vapidirs:\s*','n')
     let vapi_str = getline(vapi_line)
     return split( substitute( vapi_str, '\m^//\s*vapidirs:\s*', '', 'g' ), '\m\s\+' )
+endfunction " }}}2
+
+function! s:GetValaSources() " {{{2
+    if exists('g:syntastic_vala_sources') || exists('b:syntastic_vala_sources')
+        let sources = syntastic#util#var('vala_sources')
+        if type(sources) == type('')
+            return split(sources, '\m\s\+')
+        elseif type(sources) == type([])
+            return copy(sources)
+        else
+            echoerr 'syntastic_vala_sources must be either a list, or a string: fallback to in-file modules string'
+        endif
+    endif
+
+    let sources_line = search('^// sources: ', 'n')
+    let sources_str = getline(sources_line)
+    return split(strpart(sources_str, 12), '\m\s\+')
 endfunction " }}}2
 
 " }}}1


### PR DESCRIPTION
This adds the possibility to specify needed sources to build the current
Vala file by adding `// sources: ` at the top of the file, in the same
way as `// modules: ` and `// vapi_dirs: `.
It was discussed in issue #1895, but I think it's handy. And optional.