### PR TITLE
Elixir checker accept optional environment

### DIFF
--- a/syntax_checkers/elixir/elixir.vim
+++ b/syntax_checkers/elixir/elixir.vim
@@ -42,6 +42,10 @@ function! SyntaxCheckers_elixir_elixir_GetLocList() dict
         \ '%E** %*[^\ ] %f:%l: %m,' .
         \ '%W%f:%l: warning: %m'
 
+    if exists('g:syntastic_elixir_compile_env')
+      let make_options['env'] = g:syntastic_elixir_compile_env
+    endif
+
     return SyntasticMake(make_options)
 endfunction
 


### PR DESCRIPTION
The solution proposed [here](https://github.com/vim-syntastic/syntastic/issues/1826) wasn't working for. elixirc reported errors on many files that mix wasn't. It must have something to do with build environments.

With this patch we can set ```let g:syntastic_elixir_compile_env = { 'MIX_ENV': 'test' }``` and
 workaround [this issue](https://github.com/phoenixframework/phoenix/issues/1165) by building in a different environment.