### PR TITLE
Fixed NerdTree being used as filename by the checker.

### DIFF
--- a/plugin/syntastic/checker.vim
+++ b/plugin/syntastic/checker.vim
@@ -182,7 +182,7 @@ function! g:SyntasticChecker.makeprgBuild(opts) abort " {{{2
     let parts = []
     call extend(parts, self._getOpt(a:opts, basename, 'exe', self.getExecEscaped()))
     call extend(parts, self._getOpt(a:opts, basename, 'args', ''))
-    call extend(parts, self._getOpt(a:opts, basename, 'fname', syntastic#util#shexpand('%')))
+    call extend(parts, self._getOpt(a:opts, basename, 'fname', syntastic#util#shexpand( expand('<afile>', 1) )))
     call extend(parts, self._getOpt(a:opts, basename, 'post_args', ''))
     call extend(parts, self._getOpt(a:opts, basename, 'tail', ''))
 


### PR DESCRIPTION
Hi there,

first, thanks for the awesome package! Lately, I have being having issues when using syntastic together with NERDTree plugin. In some circumstances, when I saved the file, it was complaining that the file didn't exist, and this was due to the fact that it was using the NERDTree buffer name instead of the file.

I tried to track down what was happening today, and discovered that, for some reason, the BufWritePost was being called with @% set to the NerdTree, and because of this fname on the g:SyntasticChecker.makeprgBuild(opts) function was failing. Thus, I changed the fname value to be retrieved through syntastic#util#shexpand( expand('<afile>', 1) )), instead using '%'.

Hope it does not crashes other cases, but it seems to be working nice :D

