### PR TITLE
Checker c: look up config in the work directory

### DIFF
--- a/autoload/syntastic/c.vim
+++ b/autoload/syntastic/c.vim
@@ -23,6 +23,9 @@ function! syntastic#c#ReadConfig(file) abort " {{{2
     " search upwards from the current file's directory
     let config = syntastic#util#findFileInParent(a:file, expand('%:p:h', 1))
     if config ==# ''
+        let config = syntastic#util#findFileInParent(a:file, expand(getcwd(), 1))
+    endif
+    if config ==# ''
         call syntastic#log#debug(g:_SYNTASTIC_DEBUG_CHECKERS, 'ReadConfig: file not found')
         return ''
     endif


### PR DESCRIPTION
The GNU autotools have the concept of VPATH builds [1] with different
directories for the source tree (srcdir) and the build tree (builddir).
It also has the possibility to generate files and feed them variables
created at configure time that can be platform-dependant. Generating
Syntastic config files could for example include CFLAGS with desired
warnings enabled so that Syntastic could report them.

Example in a `configure.ac` file:

    AC_CONFIG_FILES([
        .syntastic_c_config
        Makefile
        ...
    ])

In the `.syntastic_c_config.in` template:

    @CPPFLAGS@
    @CFLAGS@

However, this doesn't work in VPATH builds because the lookup usually
starts inside $srcdir in the directory where the C file is located. It
will now fall back to using `getcwd()` if nothing was found and allow
Syntastic to find generated config files if vim was open from $builddir.

This change is made in the C checker instead of the utility function 
because other language stacks may expect different behavior when it 
comes to generated files. CMake has a similar out-of-source build [2] 
feature, it is even recommended. For the autotools, VPATH builds must
work during a `make distcheck`, which makes them more than recommended.

[1] https://www.gnu.org/software/automake/manual/html_node/VPATH-Builds.html
[2] https://cmake.org/Wiki/CMake_FAQ#What_is_an_.22out-of-source.22_build.3F