### PR TITLE
[haxe] disable output during syntax check

### DIFF
--- a/syntax_checkers/haxe/haxe.vim
+++ b/syntax_checkers/haxe/haxe.vim
@@ -32,7 +32,8 @@ function! SyntaxCheckers_haxe_haxe_GetLocList() dict
 
     if hxml !=# ''
         let makeprg = self.makeprgBuild({
-            \ 'fname': syntastic#util#shescape(fnamemodify(hxml, ':t')) })
+            \ 'fname': syntastic#util#shescape(fnamemodify(hxml, ':t')), 
+            \ 'args_after' :  ['--no-output'] })
 
         let errorformat = '%E%f:%l: characters %c-%n : %m'
 


### PR DESCRIPTION
This small change takes advantage of an argument that prevents haxe from generating output  (or executing external commands) during an otherwise normal compilation.

(edited : not new)