### PR TITLE
Improving flow check speed

### DIFF
--- a/syntax_checkers/javascript/flow.vim
+++ b/syntax_checkers/javascript/flow.vim
@@ -34,7 +34,7 @@ function! SyntaxCheckers_javascript_flow_GetLocList() dict
     endif
 
     let makeprg = self.makeprgBuild({
-        \ 'exe': self.getExecEscaped() . ' check',
+        \ 'exe': self.getExecEscaped() . ' status',
         \ 'args_after': '--show-all-errors --json' })
 
     let errorformat =


### PR DESCRIPTION
Flow keep a server running when executed with `status` command which reduces time of future checks.