### PR TITLE
[haxe] add warning indicator to errorformat

### DIFF
--- a/syntax_checkers/haxe/haxe.vim
+++ b/syntax_checkers/haxe/haxe.vim
@@ -35,7 +35,8 @@ function! SyntaxCheckers_haxe_haxe_GetLocList() dict
             \ 'fname': syntastic#util#shescape(fnamemodify(hxml, ':t')), 
             \ 'args_after' :  ['--no-output'] })
 
-        let errorformat = '%E%f:%l: characters %c-%n : %m'
+        let errorformat = '%W%f:%l: characters %c-%n : Warning : %m,' .
+            \ '%E%f:%l: characters %c-%n : %m'
 
         let loclist = SyntasticMake({
             \ 'makeprg': makeprg,


### PR DESCRIPTION
The haxe compiler can emit warnings in some cases.  This change configures the errorformat to handle that correctly.