### PR TITLE
config: add a variable to disable checks after writing

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -186,6 +186,7 @@ let g:syntastic_always_populate_loc_list = 1
 let g:syntastic_auto_loc_list = 1
 let g:syntastic_check_on_open = 1
 let g:syntastic_check_on_wq = 0
+let g:syntastic_check_on_write = 1
 ```
 
 <a name="faq"></a>

--- a/doc/syntastic.txt
+++ b/doc/syntastic.txt
@@ -127,6 +127,7 @@ needed: >
     let g:syntastic_auto_loc_list = 1
     let g:syntastic_check_on_open = 1
     let g:syntastic_check_on_wq = 0
+    let g:syntastic_check_on_write = 1
 <
 ==============================================================================
 2. Functionality provided                            *syntastic-functionality*
@@ -348,6 +349,13 @@ disk, even when the writes happen just before quitting Vim. If you want to
 skip checks when you issue `:wq`, `:x`, and `:ZZ`, set this variable to 0: >
     let g:syntastic_check_on_wq = 0
 <
+                                                  *'syntastic_check_on_write'*
+Type: boolean
+Default: 1
+In active mode syntax checks are normally run whenever buffers are written.
+If you want to skip checks when you issue `:w`, set this variable to 0: >
+    let g:syntastic_check_on_write = 0
+
                                                 *'syntastic_aggregate_errors'*
 Type: boolean
 Default: 0

--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -87,6 +87,7 @@ let g:_SYNTASTIC_DEFAULTS = {
         \ 'auto_loc_list':            2,
         \ 'check_on_open':            0,
         \ 'check_on_wq':              1,
+        \ 'check_on_write':           1,
         \ 'cursor_columns':           1,
         \ 'debug':                    0,
         \ 'echo_current_error':       1,
@@ -306,10 +307,12 @@ function! s:BufReadPostHook(fname) abort " {{{2
 endfunction " }}}2
 
 function! s:BufWritePostHook(fname) abort " {{{2
-    let buf = syntastic#util#fname2buf(a:fname)
-    call syntastic#log#debug(g:_SYNTASTIC_DEBUG_AUTOCOMMANDS,
-        \ 'autocmd: BufWritePost, buffer ' . buf . ' = ' . string(a:fname))
-    call s:UpdateErrors(buf, 1, [])
+    if g:syntastic_check_on_write
+        let buf = syntastic#util#fname2buf(a:fname)
+        call syntastic#log#debug(g:_SYNTASTIC_DEBUG_AUTOCOMMANDS,
+            \ 'autocmd: BufWritePost, buffer ' . buf . ' = ' . string(a:fname))
+        call s:UpdateErrors(buf, 1, [])
+    endif
 endfunction " }}}2
 
 function! s:BufEnterHook(fname) abort " {{{2


### PR DESCRIPTION
Allow users to opt-out of the write-time checks by setting
g:syntastic_check_on_write = 0.