### PR TITLE
Riot .tag files eslint support

### DIFF
--- a/syntax_checkers/riot/eslint.vim
+++ b/syntax_checkers/riot/eslint.vim
@@ -1,0 +1,79 @@
+"============================================================================
+"File:        eslint.vim
+"Description: riot syntax checker - using eslint.
+"             based on javascript checker maintained by Maksim Ryzhikov.
+"Maintainer:  Svetlana Linuxenko <linuxenko at gmail dot com>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"============================================================================
+
+if exists('g:loaded_syntastic_riot_eslint_checker')
+    finish
+endif
+let g:loaded_syntastic_riot_eslint_checker = 1
+
+if !exists('g:syntastic_riot_eslint_sort')
+    let g:syntastic_riot_eslint_sort = 1
+endif
+
+if !exists('g:syntastic_riot_eslint_generic')
+    let g:syntastic_riot_eslint_generic = 0
+endif
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_riot_eslint_IsAvailable() dict
+    if g:syntastic_riot_eslint_generic
+        call self.log('generic eslint, exec =', self.getExec())
+    endif
+
+    if !executable(self.getExec())
+        return 0
+    endif
+    return g:syntastic_riot_eslint_generic || syntastic#util#versionIsAtLeast(self.getVersion(), [0, 1])
+endfunction
+
+function! SyntaxCheckers_riot_eslint_GetLocList() dict
+    if !g:syntastic_riot_eslint_generic
+        call syntastic#log#deprecationWarn('riot_eslint_conf', 'riot_eslint_args',
+            \ "'--config ' . syntastic#util#shexpand(OLD_VAR)")
+    endif
+
+    let makeprg = self.makeprgBuild({ 'args_before': (g:syntastic_riot_eslint_generic ? '' : '-f compact') })
+
+    let errorformat =
+        \ '%E%f: line %l\, col %c\, Error - %m,' .
+        \ '%W%f: line %l\, col %c\, Warning - %m'
+
+    let loclist = SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat,
+        \ 'postprocess': ['guards'] })
+
+    if !g:syntastic_riot_eslint_generic
+        if !exists('s:eslint_new')
+            let s:eslint_new = syntastic#util#versionIsAtLeast(self.getVersion(), [1])
+        endif
+
+        if !s:eslint_new
+            for e in loclist
+                let e['col'] += 1
+            endfor
+        endif
+    endif
+
+    return loclist
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'riot',
+    \ 'name': 'eslint'})
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set sw=4 sts=4 et fdm=marker:


### PR DESCRIPTION
There is a good syntax highlighting plugins for vim, such as `vim-riot`. But there is a problem with support of `.tag` files by linters and syntastic. This is a general support of riot file types for syntastic (based on javascript's eslint.vim file). 

The plugins for support `.tag` files for eslint i know:
 * `eslint-plugin-riot`
 * `eslint-plugin-peopleai` - mine, based on `eslint-plugin-riot`. 
