### PR TITLE
Honour a global .rubocop.yml

### DIFF
--- a/syntax_checkers/ruby/rubocop.vim
+++ b/syntax_checkers/ruby/rubocop.vim
@@ -26,7 +26,7 @@ function! SyntaxCheckers_ruby_rubocop_IsAvailable() dict
 endfunction
 
 function! SyntaxCheckers_ruby_rubocop_GetLocList() dict
-    let makeprg = self.makeprgBuild({ 'args_after': '--format emacs' })
+    let makeprg = self.makeprgBuild({ 'args_after': '--format emacs --force-exclusion' })
 
     let errorformat = '%f:%l:%c: %t: %m'
 


### PR DESCRIPTION
When a rubocop command receives a single file to check, it ignores
"Exclude" options in .rubocop.yml located in the project root directory.
This commit fixes that, so you don't see errors you don't expect to see.

"--force-exclusion" option is supported already for a long time
see https://github.com/bbatsov/rubocop/commit/eae27629dc6a5b27c5e90e8b32fd5914c6ae6cc2