### PR TITLE
Add typescript/standard checker

### DIFF
--- a/syntax_checkers/typescript/standard.vim
+++ b/syntax_checkers/typescript/standard.vim
@@ -1,0 +1,23 @@
+"============================================================================
+"File:        standard.vim
+"Description: Syntax checking plugin for syntastic
+"Maintainer:  LCD 47 <lcd047 at gmail dot com>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"
+"============================================================================
+
+if exists('g:loaded_syntastic_typescript_standard_checker')
+    finish
+endif
+let g:loaded_syntastic_typescript_standard_checker = 1
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'typescript',
+    \ 'name': 'standard',
+    \ 'redirect': 'javascript/standard'})
+
+" vim: set sw=4 sts=4 et fdm=marker:


### PR DESCRIPTION
Since ESLint supports TypeScript by customized parser.
Standard is also possible to lint TypeScript files.