### PR TITLE
Call uname without shell.

### DIFF
--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -56,7 +56,7 @@ if s:_running_windows
     let g:_SYNTASTIC_UNAME = 'Windows'
 elseif executable('uname')
     try
-        let g:_SYNTASTIC_UNAME = split(syntastic#util#system('uname'), "\n")[0]
+        let g:_SYNTASTIC_UNAME = split(syntastic#util#system(['uname']), "\n")[0]
     catch /\m^Vim\%((\a\+)\)\=:E484/
         call syntastic#log#error("can't run external programs (misconfigured shell options?)")
         finish


### PR DESCRIPTION
I don’t see a need to have `uname` called within a shell, calling the
program directly using the list syntax speeds up the execution of his
line by a potentially huge amount - which is good as it is run during
startup.

With shell set to `/bin/bash --login` it can take a relatively long time
to load up a login shell. Below is the difference in time for this
line during startup before and after the change, this is nearly half
a second.

```
count  total (s)   self (s)

1   0.479970   0.000027         let g:_SYNTASTIC_UNAME = split(syntastic#util#system('uname'), "\n")[0]

1   0.002503   0.000025         let g:_SYNTASTIC_UNAME = split(syntastic#util#system(['uname']), "\n")[0]
```

may solve: https://github.com/vim-syntastic/syntastic/issues/91