### PR TITLE
D-Scanner support

### DIFF
--- a/autoload/syntastic/preprocess.vim
+++ b/autoload/syntastic/preprocess.vim
@@ -424,6 +424,21 @@ function! syntastic#preprocess#validator(errors) abort " {{{2
     return out
 endfunction " }}}2
 
+function! syntastic#preprocess#dscanner(errors) abort " {{{2
+    let startIndex = index(a:errors, '{')
+    let data = join(a:errors[startIndex:], '')
+    let errs = s:_decode_JSON(data)
+
+    let out = []
+    let issues = errs['issues']
+    for issue in issues
+        let msg = issue['fileName'] . ':' . issue['line'] . ':'
+                    \ . issue['column'] . ':' . issue['message']
+        call add(out, msg)
+    endfor
+    return out
+endfunction " }}}2
+
 function! syntastic#preprocess#vint(errors) abort " {{{2
     let errs = s:_decode_JSON(join(a:errors, ''))
 

--- a/doc/syntastic-checkers.txt
+++ b/doc/syntastic-checkers.txt
@@ -1755,6 +1755,7 @@ SYNTAX CHECKERS FOR D                                   *syntastic-checkers-d*
 The following checkers are available for D (filetype "d"):
 
     1. DMD......................|syntastic-d-dmd|
+    1. D-Scanner................|syntastic-d-dscanner|
 
 ------------------------------------------------------------------------------
 1. DMD                                                       *syntastic-d-dmd*
@@ -1833,6 +1834,22 @@ This checker doesn't call the "makeprgBuild()" function, and thus it ignores
 the usual 'g:syntastic_d_dmd_<option>' variables. The only exception is
 'g:syntastic_d_dmd_exec', which can still be used to override the checker's
 executable.
+
+------------------------------------------------------------------------------
+2. D-Scanner                                             *syntastic-d-dscanner*
+
+Name:        dscanner
+Maintainer:  ANtlord
+
+"D-Scanner" is a tool for analyzing D source code (https://dlang.org/).
+See the manual for more information:
+
+    https://github.com/Hackerpilot/Dscanner
+
+Checker options~
+
+This checker is initialised using the "makeprgBuild()" function and thus it
+accepts the standard options described at |syntastic-config-makeprg|.
 
 ==============================================================================
 SYNTAX CHECKERS FOR DART                             *syntastic-checkers-dart*

--- a/plugin/syntastic/registry.vim
+++ b/plugin/syntastic/registry.vim
@@ -28,7 +28,7 @@ let s:_DEFAULT_CHECKERS = {
         \ 'css':           ['csslint'],
         \ 'cucumber':      ['cucumber'],
         \ 'cuda':          ['nvcc'],
-        \ 'd':             ['dmd', 'dscanner'],
+        \ 'd':             ['dmd'],
         \ 'dart':          ['dartanalyzer'],
         \ 'docbk':         ['xmllint'],
         \ 'dockerfile':    ['dockerfile_lint'],

--- a/plugin/syntastic/registry.vim
+++ b/plugin/syntastic/registry.vim
@@ -28,7 +28,7 @@ let s:_DEFAULT_CHECKERS = {
         \ 'css':           ['csslint'],
         \ 'cucumber':      ['cucumber'],
         \ 'cuda':          ['nvcc'],
-        \ 'd':             ['dmd'],
+        \ 'd':             ['dmd', 'dscanner'],
         \ 'dart':          ['dartanalyzer'],
         \ 'docbk':         ['xmllint'],
         \ 'dockerfile':    ['dockerfile_lint'],

--- a/syntax_checkers/d/dscanner.vim
+++ b/syntax_checkers/d/dscanner.vim
@@ -2,14 +2,6 @@
 "File:        dscanner.vim
 "Description: Syntax checking plugin for syntastic.vim
 "Maintainer:  ANtlord
-"License:     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-"             EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-"             OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-"             NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-"             HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-"             WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-"             FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-"             OTHER DEALINGS IN THE SOFTWARE.
 "
 "============================================================================
 
@@ -26,52 +18,26 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_d_dscanner_IsAvailable() dict
-    let exec = self.getExec()
-    echo exec
-    let res = executable(exec)
-    echo res
-    return res
+    let exec_file = self.getExec()
+    let is_exec = executable(exec_file)
+    if !is_exec
+        call self.log('Syntastic: D-Scanner executable file not found.')
+    endif
+    return is_exec
 endfunction
 
 function! SyntaxCheckers_d_dscanner_GetLocList() dict
-    if !has('python3')
-        echo "Syntastic: Python3 support is necessary for dscanner."
-        finish
-    endif
     let makeprg = self.makeprgBuild({
                 \ 'args': '--report',
+                \ 'tail': '2>/dev/null',
                 \ 'args_after': '' })
-py3 << EOF
-import vim
-import subprocess as sp
-import json
-filename = vim.current.buffer.name
-buffernumber = vim.current.buffer.number
-command = vim.eval('makeprg').split()
-result = sp.run(command, stdout=sp.PIPE, stderr=sp.DEVNULL)
-output = result.stdout.decode().replace('\n', '')
 
-json_start = output.find('{')
-
-output_for_json = output[json_start:]
-error_data = json.loads(output_for_json)
-issues = error_data['issues']
-
-messages = []
-for issue in issues:
-    messages.append({
-        'bufnr': buffernumber,
-        'lnum': issue['line'],
-        'col': issue['column'],
-        'nr': -1,
-        'text': issue['message'],
-        'type': 'error',
-        'valid': 1
-    })
- 
-vim.command('let result = %s' % messages)
-EOF
-    return result
+    let errorformat = '%f:%l:%c:%m'
+    let loclist = SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat,
+        \ 'preprocess': 'dscanner'})
+    return loclist
 endfunction
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({

--- a/syntax_checkers/d/dscanner.vim
+++ b/syntax_checkers/d/dscanner.vim
@@ -1,0 +1,85 @@
+"============================================================================
+"File:        dscanner.vim
+"Description: Syntax checking plugin for syntastic.vim
+"Maintainer:  ANtlord
+"License:     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+"             EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+"             OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+"             NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+"             HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+"             WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+"             FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+"             OTHER DEALINGS IN THE SOFTWARE.
+"
+"============================================================================
+
+if exists('g:loaded_syntastic_d_dscanner_checker')
+    finish
+endif
+let g:loaded_syntastic_d_dscanner_checker = 1
+
+if !exists('g:syntastic_d_dscanner_sort')
+    let g:syntastic_d_dscanner_sort = 1
+endif
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_d_dscanner_IsAvailable() dict
+    let exec = self.getExec()
+    echo exec
+    let res = executable(exec)
+    echo res
+    return res
+endfunction
+
+function! SyntaxCheckers_d_dscanner_GetLocList() dict
+    if !has('python3')
+        echo "Syntastic: Python3 support is necessary for dscanner."
+        finish
+    endif
+    let makeprg = self.makeprgBuild({
+                \ 'args': '--report',
+                \ 'args_after': '' })
+py3 << EOF
+import vim
+import subprocess as sp
+import json
+filename = vim.current.buffer.name
+buffernumber = vim.current.buffer.number
+command = vim.eval('makeprg').split()
+result = sp.run(command, stdout=sp.PIPE, stderr=sp.DEVNULL)
+output = result.stdout.decode().replace('\n', '')
+
+json_start = output.find('{')
+
+output_for_json = output[json_start:]
+error_data = json.loads(output_for_json)
+issues = error_data['issues']
+
+messages = []
+for issue in issues:
+    messages.append({
+        'bufnr': buffernumber,
+        'lnum': issue['line'],
+        'col': issue['column'],
+        'nr': -1,
+        'text': issue['message'],
+        'type': 'error',
+        'valid': 1
+    })
+ 
+vim.command('let result = %s' % messages)
+EOF
+    return result
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+            \ 'filetype': 'd',
+            \ 'name': 'dscanner',
+            \ 'exec': 'dscanner' })
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set sw=4 sts=4 et fdm=marker:


### PR DESCRIPTION
Hello!

This PR adds one more [D](https://dlang.org) checker based on [D-Scanner](https://github.com/Hackerpilot/Dscanner). I developed extension using Python 3 because D-Scanner provides JSON output. Handling JSON data using Python is easy and choose that language. If usage of Python 3 is critically bad for maintaining Syntastic I can develop the extension using VimSript.