### PR TITLE
add racket syntax checker by running `raco expand`, which is far safe…

### DIFF
--- a/doc/syntastic-checkers.txt
+++ b/doc/syntastic-checkers.txt
@@ -5086,6 +5086,7 @@ The following checkers are available for Racket (filetype "racket"):
 
     1. code-ayatollah...........|syntastic-racket-code-ayatollah|
     2. racket...................|syntastic-racket-racket|
+	3. raco.....................|syntastic-racket-raco|
 
 ------------------------------------------------------------------------------
 1. code-ayatollah                            *syntastic-racket-code-ayatollah*
@@ -5130,6 +5131,22 @@ over a global one in the buffers where it is defined.
 Please note that setting this variable doesn't automatically enable the
 checker, you still need to add "racket" to 'g:syntastic_racket_checkers' if
 you plan to use it.
+
+Checker options~
+
+This checker is initialised using the "makeprgBuild()" function and thus it
+accepts the standard options described at |syntastic-config-makeprg|.
+
+-----------------------------------------------------------------------------
+3. raco                                                 *syntastic-racket-raco*
+
+Name:        raco
+Maintainer:  Nymphium <s1311350@coins.tsukuba.ac.jp>
+
+"raco" supports various Racket tasks from a command line.
+See the reference manual for details:
+
+    *https://docs.racket-lang.org/raco/*
 
 Checker options~
 

--- a/syntax_checkers/racket/raco.vim
+++ b/syntax_checkers/racket/raco.vim
@@ -1,0 +1,48 @@
+"============================================================================
+"File:        raco.vim
+"Description: Syntax checking plugin for syntastic.vim
+"Maintainer:  Nymphium
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"============================================================================
+
+if exists('g:loaded_syntastic_racket_raco_checker')
+    finish
+endif
+let g:loaded_syntastic_racket_raco_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_racket_raco_GetHighlightRegex(item)
+    if matchstr(a:item['text'], '\<type mismatch\>') !=# ''
+        return '\V' . matchstr(a:item['text'], 'in: \zs.\+$')
+    endif
+
+    return ''
+endfunction
+
+function! SyntaxCheckers_racket_raco_GetLocList() dict
+    let makeprg = self.makeprgBuild({'args_before': 'expand'})
+
+    let errorformat =
+        \ '%E%f:%l:%v: Type Checker: %m,%+C  expected:%m,%+C  given:%m,%Z %m,' .
+        \ '%E%f:%l:%v: %m,' .
+        \ '%-G%.%#'
+
+    return SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat })
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'racket',
+    \ 'name': 'raco' })
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set sw=4 sts=4 et fdm=marker:


### PR DESCRIPTION
add racket syntax checker by running `raco expand`, which is far safer than running `racket`