### PR TITLE
Fix format option of dartanalyzer: `--machine` option is deprecated

### DIFF
--- a/syntax_checkers/dart/dartanalyzer.vim
+++ b/syntax_checkers/dart/dartanalyzer.vim
@@ -30,7 +30,7 @@ function! SyntaxCheckers_dart_dartanalyzer_GetHighlightRegex(error)
 endfunction
 
 function! SyntaxCheckers_dart_dartanalyzer_GetLocList() dict
-    let makeprg = self.makeprgBuild({ 'args_after': '--machine' })
+    let makeprg = self.makeprgBuild({ 'args_after': '--format=machine' })
 
     " Machine readable format looks like:
     " SEVERITY|TYPE|ERROR_CODE|FILENAME|LINE_NUMBER|COLUMN|LENGTH|MESSAGE


### PR DESCRIPTION
`--machine` format is deprecated.
I changed to use `--format=machine` option instead of `--machine`.