### PR TITLE
Fixing error parsing for tslint v5

### DIFF
--- a/syntax_checkers/typescript/tslint.vim
+++ b/syntax_checkers/typescript/tslint.vim
@@ -26,12 +26,20 @@ function! SyntaxCheckers_typescript_tslint_GetLocList() dict
         let s:tslint_new = syntastic#util#versionIsAtLeast(self.getVersion(), [2, 4])
     endif
 
+    if !exists('s:tslint_major_version')
+        let s:tslint_major_version = self.getVersion()[0]
+    endif
+
     let makeprg = self.makeprgBuild({
-        \ 'args_after': '--format verbose',
         \ 'fname_before': (s:tslint_new ? '' : '-f') })
 
-    " (comment-format) ts/app.ts[12, 36]: comment must start with lowercase letter
-    let errorformat = '%f[%l\, %c]: %m'
+    " Example output:
+    " ts/app.ts[12, 36]: comment must start with lowercase letter
+    if s:tslint_major_version >= 5
+        let errorformat = 'ERROR: %f[%l\, %c]: %m'
+    else
+        let errorformat = '%f[%l\, %c]: %m'
+    endif
 
     return SyntasticMake({
         \ 'makeprg': makeprg,

--- a/syntax_checkers/typescript/tslint.vim
+++ b/syntax_checkers/typescript/tslint.vim
@@ -30,7 +30,18 @@ function! SyntaxCheckers_typescript_tslint_GetLocList() dict
         let s:tslint_major_version = self.getVersion()[0]
     endif
 
+    if exists(':TsuStartServer')
+        " If tsuquyomi is installed, ask for the config file name
+        let s:tsconfig = tsuquyomi#tsClient#tsProjectInfo(@%, 0)['configFileName']
+
+        if s:tslint_major_version >= 5
+            " tslint v5 requires tsconfig file specified for some rules
+            let s:tsargs = '--type-check -p ' . s:tsconfig
+        endif
+    endif
+
     let makeprg = self.makeprgBuild({
+        \ 'args_after': (exists('s:tsargs') ? s:tsargs : ''),
         \ 'fname_before': (s:tslint_new ? '' : '-f') })
 
     " Example output:


### PR DESCRIPTION
Tested to work against tslint `3.15.0`, `4.1.0`, and `5.1.0`.