### PR TITLE
Ensure that php lint errors are reported to standard out

### DIFF
--- a/syntax_checkers/php/php.vim
+++ b/syntax_checkers/php/php.vim
@@ -25,7 +25,7 @@ endfunction
 
 function! SyntaxCheckers_php_php_GetLocList() dict
     let makeprg = self.makeprgBuild({
-        \ 'args': '-d error_reporting=E_ALL',
+        \ 'args': '-d error_log= -d error_reporting=E_ALL',
         \ 'args_after': '-l -d display_errors=1 -d log_errors=0 -d xdebug.cli_color=0' })
 
     let errorformat =


### PR DESCRIPTION
If error_log has been set in php.ini this resets it to the default