### PR TITLE
[gotype] Update argument for checking test file.

### DIFF
--- a/syntax_checkers/go/gotype.vim
+++ b/syntax_checkers/go/gotype.vim
@@ -21,7 +21,7 @@ set cpo&vim
 function! SyntaxCheckers_go_gotype_GetLocList() dict
     let buf = bufnr('')
     let makeprg = self.makeprgBuild({
-        \ 'args': (bufname(buf) =~# '\m_test\.go$' ? '-a' : ''),
+        \ 'args': (bufname(buf) =~# '\m_test\.go$' ? '-t' : ''),
         \ 'fname': '.' })
 
     let errorformat =


### PR DESCRIPTION
This argument changed from `-a` to `-t` in the recent past. It needs to be updated in order to be able to check `*_test.go` files.

See documentation here: https://godoc.org/golang.org/x/tools/cmd/gotype

Making this update fixed the issue for me.