### PR TITLE
Support coffeescript linting with coffee-jshint

### DIFF
--- a/doc/syntastic-checkers.txt
+++ b/doc/syntastic-checkers.txt
@@ -1615,6 +1615,7 @@ The following checkers are available for CoffeeScript (filetype "coffee"):
 
     1. Coffee...................|syntastic-coffee-coffee|
     2. CoffeeLint...............|syntastic-coffee-coffeelint|
+    3. coffee_jshint............|syntastic-coffee-coffee-jshint|
 
 ------------------------------------------------------------------------------
 1. Coffee                                            *syntastic-coffee-coffee*
@@ -1648,6 +1649,22 @@ Checker options~
 
 This checker is initialised using the "makeprgBuild()" function and thus it
 accepts the standard options described at |syntastic-config-makeprg|.
+
+------------------------------------------------------------------------------
+2. coffee-jshint                               *syntastic-coffee-coffee-jshint*
+
+Name:        coffee-jshint
+Maintainer:  John Krauss <john@johnkrauss.com>
+
+"coffee-jshint" is a JSHint validator for CoffeeScript. See the project's page
+for details:
+
+    https://github.com/marviq/coffee-jshint
+
+Checker options~
+
+This checker is initialised using the "makeprgBuild()" function and thus it
+Accepts the standard options described at |syntastic-config-makeprg|.
 
 ==============================================================================
 SYNTAX CHECKERS FOR COQ                               *syntastic-checkers-coq*

--- a/plugin/syntastic/registry.vim
+++ b/plugin/syntastic/registry.vim
@@ -22,7 +22,7 @@ let s:_DEFAULT_CHECKERS = {
         \ 'cmake':         ['cmakelint'],
         \ 'co':            ['coco'],
         \ 'cobol':         ['cobc'],
-        \ 'coffee':        ['coffee', 'coffeelint'],
+        \ 'coffee':        ['coffee', 'coffeelint', 'coffee_jshint'],
         \ 'coq':           ['coqtop'],
         \ 'cpp':           ['gcc'],
         \ 'cs':            ['mcs'],

--- a/syntax_checkers/coffee/coffee-jshint.vim
+++ b/syntax_checkers/coffee/coffee-jshint.vim
@@ -1,0 +1,45 @@
+"============================================================================
+"File:        coffee-jshint.vim
+"Description: Syntax checking plugin for syntastic.vim
+"Maintainer:  John Krauss <john@johnkrauss.com>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"
+"============================================================================
+
+if exists('g:loaded_syntastic_coffee_coffee_jshint_checker')
+    finish
+endif
+let g:loaded_syntastic_coffee_coffee_jshint_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_coffee_coffee_jshint_GetLocList() dict
+    let makeprg = self.makeprgBuild({})
+
+    let errorformat =
+        \ '--------------------------------,' .
+        \ '%+P%f,' .
+        \ '%l:%c: %m,' .
+        \ '%-Q'
+
+    return SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat,
+        \ 'returns': [0, 1]})
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'coffee',
+    \ 'exec': 'coffee-jshint',
+    \ 'name': 'coffee_jshint'})
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set sw=4 sts=4 et fdm=marker:
+


### PR DESCRIPTION
Adds support for the [coffee-jshint](https://github.com/marviq/coffee-jshint) error checker for Coffeescript.