### PR TITLE
Make ruby FAQ section more idiomatic

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -436,16 +436,27 @@ scripts.
 
 __4.12. Q. How can I check scripts written for different versions of Ruby?__
 
-A. Install a Ruby version manager such as [rvm][rvm] or [rbenv][rbenv],
-activate the environment for the relevant version of Ruby, and install in it
-the checkers you want to use.  Set `g:syntastic_ruby_checkers` accordingly in
-your `vimrc`, and run [Vim][vim] from the virtual environment.
+A. Install a Ruby version manager such as [rvm][rvm],  [rbenv][rbenv],
+[chruby][chruby] or [ry][ry], activate the relevant version of Ruby, and
+install in it the checkers you want to use.  Set `g:syntastic_ruby_checkers`
+accordingly in your `vimrc`, and run [Vim][vim] from the environment or
+location where the relevant ruby version will be active.
 
-If you're starting Vim from a desktop manager rather than from a terminal you
-might need to write wrapper scripts around your checkers, to activate the
-virtual environment before running the actual checks.  Then you'll need to
-point the relevant `g:syntastic_ruby_<checker>_exec` variables to the wrapper
-scripts.
+If you're starting Vim from a desktop manager rather than from a terminal and
+depending on the version manager you use, you might need to write wrapper
+scripts around your checkers, to activate the relevant version of ruby before
+running the actual checks.  Then you'll need to point the relevant
+`g:syntastic_ruby_<checker>_exec` variables to the wrapper scripts.
+
+With rvm gemsets the above will be sufficient but if you rely on bundler and
+the Gemfile to lock the checker versions you may want to either make use of
+`RUBYGEMS_GEMDEPS='-'`, install the [rubygems-bundler][rubygems-bundler] gem,
+or instruct Syntastic to use `bundle exec`. In all cases you will need to make
+sure the linter is run from the correct directory or use the environment
+variable `BUNDLE_GEMFILE` for bundler to catch the proper Gemfile while also
+pointing the checker to its eventual configuration file (e.g `rubocop
+--config`). This can be done in a wrapper script or by adjusting your `vimrc`
+configuration.
 
 <a name="faqperl"></a>
 


### PR DESCRIPTION
The ruby section of FAQ has been updated, removing terms and references that were pythonic, as the equivalent of pyenv/venv is typically handled separately in ruby land.

Sadly *"by adjusting your vim configuration"* is a cop out. I initially wanted to include some vimscript example but I quickly hit a number of roadblocks. It would look something like this inspired by the JS one, but:

- The `--gemfile` arg does not exist for `bundle exec`... yet (it does for `install`)
- It should be applied to `bundle exec`, not `rubocop`, which AFAIK is not possible to do with the current syntastic variables (see additional note below).

```vim
let g:syntastic_ruby_rubocop_exe = 'bundle exec rubocop'

function! FindConfig(prefix, what, where)
    let cfg = findfile(a:what, escape(a:where, ' ') . ';')
    return cfg !=# '' ? ' ' . a:prefix . ' ' . shellescape(cfg) : ''
endfunction

autocmd FileType ruby let b:syntastic_ruby_rubocop_args =
    \ get(g:, 'syntastic_ruby_rubocop_args', '') .
    \ FindConfig('--gemfile', 'Gemfile', expand('<afile>:p:h', 1))
```

I wonder if there could/should be a completely generic notion of wrapper in syntastic that would help in wrapping things and passing args to the right place, so that the following could be conditionally and programmatically set by the user like `b:syntastic_*_*_args` on a custom case by case basis (e.g presence of `Gemfile` or not), something to the effect of:

```vim
" Gemfile and .rubocop.yml found via something like FindConfig
let b:syntastic_ruby_rubocop_wrapper = 'env BUNDLE_GEMFILE=/some/where/Gemfile bundle exec'
let b:b:syntastic_ruby_rubocop_args = '--config /some/where/.rubocop.yml'
```