### PR TITLE
Improve chktex format to handle the column number.

### DIFF
--- a/syntax_checkers/tex/chktex.vim
+++ b/syntax_checkers/tex/chktex.vim
@@ -27,12 +27,12 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_tex_chktex_GetLocList() dict
-    let makeprg = self.makeprgBuild({ 'args_after': '-q -v1' })
+    let makeprg = self.makeprgBuild({ 'args_after': "-q -f \"%k:%n:%f:%l:%c:%m\n\"" })
 
     let errorformat =
-        \ '%EError %n in %f line %l: %m,' .
-        \ '%WWarning %n in %f line %l: %m,' .
-        \ (g:syntastic_tex_chktex_showmsgs ? '%WMessage %n in %f line %l: %m,' : '') .
+        \ '%EError:%n:%f:%l:%c:%m,' .
+        \ '%WWarning:%n:%f:%l:%c:%m,' .
+        \ (g:syntastic_tex_chktex_showmsgs ? '%WMessage:%n:%f:%l:%c:%m,' : '') .
         \ '%Z%p^,' .
         \ '%-G%.%#'
 


### PR DESCRIPTION
Up to now `chktex` is used with the `-v1` switch so that the column number was not given in the output of `chktex`.

In this pull request the output format of `chktex` was changed to also give the column number and the `errorformat` is adapted accordingly.