### PR TITLE
Adding pug_lint_vue as first Vue.JS checker

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -61,14 +61,14 @@ Source Language, ActionScript, Ada, Ansible configurations, API Blueprint,
 AppleScript, AsciiDoc, Assembly languages, BEMHTML, Bro, Bourne shell, C, C++,
 C#, Cabal, Chef, CMake, CoffeeScript, Coco, Coq, CSS, Cucumber, CUDA, D, Dart,
 DocBook, Dockerfile, Dust, Elixir, Erlang, eRuby, Fortran, Gentoo metadata,
-GLSL, Go, Haml, Haskell, Haxe, Handlebars, HSS, HTML, Java, JavaScript,
-JSON, JSX, Julia, LESS, Lex, Limbo, LISP, LLVM intermediate language, Lua,
-Markdown, MATLAB, Mercury, NASM, Nix, Objective-C, Objective-C++, OCaml, Perl,
-Perl POD, PHP, gettext Portable Object, OS X and iOS property lists, Pug
-(formerly Jade), Puppet, Python, QML, R, Racket, RDF TriG, RDF Turtle, Relax
-NG, reStructuredText, RPM spec, Ruby, SASS/SCSS, Scala, Slim, SML, Solidity,
-Sphinx, SQL, Stylus, Tcl, TeX, Texinfo, Twig, TypeScript, Vala, Verilog, VHDL,
-Vim help, VimL, xHtml, XML, XSLT, XQuery, YACC, YAML, YANG data models, z80,
+GLSL, Go, Haml, Haskell, Haxe, Handlebars, HSS, HTML, Java, JavaScript, JSON,
+JSX, Julia, LESS, Lex, Limbo, LISP, LLVM intermediate language, Lua, Markdown,
+MATLAB, Mercury, NASM, Nix, Objective-C, Objective-C++, OCaml, Perl, Perl POD,
+PHP, gettext Portable Object, OS X and iOS property lists, Pug (formerly Jade),
+Puppet, Python, QML, R, Racket, RDF TriG, RDF Turtle, Relax NG,
+reStructuredText, RPM spec, Ruby, SASS/SCSS, Scala, Slim, SML, Solidity, Sphinx,
+SQL, Stylus, Tcl, TeX, Texinfo, Twig, TypeScript, Vala, Verilog, VHDL, Vim help,
+VimL, Vue.js, xHtml, XML, XSLT, XQuery, YACC, YAML, YANG data models, z80,
 Zope page templates, and Zsh. See the [manual][checkers] for details about the
 corresponding supported checkers (`:help syntastic-checkers` in Vim).
 

--- a/doc/syntastic-checkers.txt
+++ b/doc/syntastic-checkers.txt
@@ -121,6 +121,7 @@ SYNTAX CHECKERS BY LANGUAGE                          *syntastic-checkers-lang*
     VHDL.....................................|syntastic-checkers-vhdl|
     Vim help.................................|syntastic-checkers-help|
     VimL.....................................|syntastic-checkers-vim|
+    Vue.js...................................|syntastic-checkers-vue|
 
     xHTML....................................|syntastic-checkers-xhtml|
     XML......................................|syntastic-checkers-xml|
@@ -7031,6 +7032,34 @@ details:
 
     https://github.com/Kuniwak/vint
 
+Checker options~
+
+This checker is initialised using the "makeprgBuild()" function and thus it
+accepts the standard options described at |syntastic-config-makeprg|.
+
+==============================================================================
+SYNTAX CHECKERS FOR VUE.JS                            *syntastic-checkers-vue*
+
+The following checkers are available for Vue.js (filetype "vue"):
+
+    1. pug_lint_vue..............|syntastic-vue-pug_lint_vue|
+
+------------------------------------------------------------------------------
+1. pug_lint_vue                               *syntastic-vue-pug_lint_vue*
+
+Name:        pug_lint_vue
+Maintainer:  Tim Carry <tim@pixelastic.com>
+
+"pug-lint-vue" is a linter for Pug templates inside of Vue.js components. See
+the project's page at GitHub for details:
+
+    https://github.com/sourceboat/pug-lint-vue
+
+Installation~
+
+Install it with: >
+    npm install -g pug-lint-vue
+<
 Checker options~
 
 This checker is initialised using the "makeprgBuild()" function and thus it

--- a/plugin/syntastic/registry.vim
+++ b/plugin/syntastic/registry.vim
@@ -103,6 +103,7 @@ let s:_DEFAULT_CHECKERS = {
         \ 'verilog':       ['verilator'],
         \ 'vhdl':          ['ghdl'],
         \ 'vim':           ['vimlint'],
+        \ 'vue':           ['pug_lint_vue'],
         \ 'xhtml':         ['tidy'],
         \ 'xml':           ['xmllint'],
         \ 'xslt':          ['xmllint'],

--- a/syntax_checkers/vue/pug_lint_vue.vim
+++ b/syntax_checkers/vue/pug_lint_vue.vim
@@ -1,0 +1,44 @@
+"============================================================================
+"File:        pug_lint_vue.vim
+"Description: Syntax checking plugin for syntastic.vim using pug-lint-vue
+"             (https://github.com/sourceboat/pug-lint-vue)
+"Maintainer:  Tim Carry <tim at pixelastic dot com>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"
+"============================================================================
+
+if exists('g:loaded_syntastic_vue_pug_lint_vue_checker')
+    finish
+endif
+let g:loaded_syntastic_vue_pug_lint_vue_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_vue_pug_lint_vue_GetLocList() dict
+    let makeprg = self.makeprgBuild({ 'fname': expand('%:p') })
+
+    let errorformat = '  %l:%c %m'
+
+    return SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat,
+        \ 'defaults': {
+            \ 'bufnr': bufnr(''),
+            \ 'type': 'E'
+        \ } })
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'vue',
+    \ 'name': 'pug_lint_vue',
+    \ 'exec': 'pug-lint-vue' })
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set sw=4 sts=4 et fdm=marker:


### PR DESCRIPTION
As per #2071, here is `pug-lint-vue` as the first checker for Vue.js (`.vue`) files. 

I did not add `eslint` as another default checker for `.vue` files. Not sure how to do it actually.

Took me a while to understand that I had to rename `pug-lint-vue` to `pug_lint_vue` when naming it inside of syntastic. Took me even longer to catch that `pug-lint-vue filename.vue` was not doing anything and that I had to force a `./filename.vue` (or an absolute path).

I've manually updated the documentation as well.