### PR TITLE
PHPStan - require version 0.8.5 or higher

### DIFF
--- a/doc/syntastic-checkers.txt
+++ b/doc/syntastic-checkers.txt
@@ -4751,7 +4751,7 @@ See the project's page iat GitHub for details:
 
     https://github.com/phpstan/phpstan
 
-Syntastic supports "PHPStan" versions 0.7 and later.
+Syntastic supports "PHPStan" versions 0.8.5 and later.
 
 Checker options~
 

--- a/syntax_checkers/php/phpstan.vim
+++ b/syntax_checkers/php/phpstan.vim
@@ -22,7 +22,7 @@ function! SyntaxCheckers_php_phpstan_IsAvailable() dict
     if !executable(self.getExec())
         return 0
     endif
-    return syntastic#util#versionIsAtLeast(self.getVersion(), [0, 7])
+    return syntastic#util#versionIsAtLeast(self.getVersion(), [0, 8, 5])
 endfunction
 
 function! SyntaxCheckers_php_phpstan_GetLocList() dict


### PR DESCRIPTION
Version number is then correctly displayed by executables from composer.

https://github.com/phpstan/phpstan/issues/160#issuecomment-322040877