### PR TITLE
C++ checker: Set default gcc flags to use C++11

### DIFF
--- a/syntax_checkers/cpp/gcc.vim
+++ b/syntax_checkers/cpp/gcc.vim
@@ -40,7 +40,7 @@ function! SyntaxCheckers_cpp_gcc_GetLocList() dict
         \     '%f:%l: %trror: %m,'.
         \     '%f:%l: %tarning: %m,'.
         \     '%f:%l: %m',
-        \ 'main_flags': '-x c++ -fsyntax-only',
+        \ 'main_flags': '-x c++ -std=gnu++11 -fsyntax-only',
         \ 'header_flags': '-x c++',
         \ 'header_names': '\m\.\(h\|hpp\|hh\)$' })
 endfunction


### PR DESCRIPTION
GCC has had support for C++11 for a long time now, so it's the appropriate default version of C++ coming from the upstream syntastic repo. Note that C++11 is for all intents and purposes backward-compatible to older C++ versions. Also, I'm assuming that a lot of people have local settings that make C++11 (or even 14) the default, so I suggest upstreaming C++11 as the default.