### PR TITLE
Improvements for 'scalac' checker borrowing from 'fsc' checker

### DIFF
--- a/syntax_checkers/scala/scalac.vim
+++ b/syntax_checkers/scala/scalac.vim
@@ -25,6 +25,7 @@ function! SyntaxCheckers_scala_scalac_GetLocList() dict
 
     let errorformat =
         \ '%E%f:%l: %trror: %m,' .
+        \ '%W%f:%l: %tarning:%m,' .
         \ '%Z%p^,' .
         \ '%-G%.%#'
 

--- a/syntax_checkers/scala/scalac.vim
+++ b/syntax_checkers/scala/scalac.vim
@@ -21,7 +21,7 @@ set cpo&vim
 function! SyntaxCheckers_scala_scalac_GetLocList() dict
     call syntastic#log#deprecationWarn('scala_options', 'scala_scalac_args')
 
-    let makeprg = self.makeprgBuild({ 'args_after': '-Ystop-after:parser' })
+    let makeprg = self.makeprgBuild({ 'args': '-Ystop-after:parser' })
 
     let errorformat =
         \ '%E%f:%l: %trror: %m,' .


### PR DESCRIPTION
Since the `scalac` compiler and `fsc` compilers are identical (one simply wraps the other to keep it hot-cached in memory), improvements from one can be moved to the other. This pull request borrows a couple of changes from `fsc`'s checker and moves them into the `scalac` checker.