### PR TITLE
New checker for C#: csc

### DIFF
--- a/doc/syntastic-checkers.txt
+++ b/doc/syntastic-checkers.txt
@@ -985,6 +985,7 @@ SYNTAX CHECKERS FOR C#                                 *syntastic-checkers-cs*
 The following checkers are available for C# (filetype "cs"):
 
     1. mcs......................|syntastic-cs-mcs|
+    2. csc......................|syntastic-cs-csc|
 
 ------------------------------------------------------------------------------
 1. mcs                                                      *syntastic-cs-mcs*
@@ -996,6 +997,27 @@ Maintainer:  Daniel Walker <dwalker@fifo99.com>
 (http://www.mono-project.com/Main_Page). See the program's manual for details:
 
     http://mono.wikia.com/wiki/Man_mcs
+
+Checker options~
+
+This checker is initialised using the "makeprgBuild()" function and thus it
+accepts the standard options described at |syntastic-config-makeprg|.
+
+------------------------------------------------------------------------------
+2. csc                                                      *syntastic-cs-csc*
+
+Name:        csc
+Maintainer:  Martin Aumont <martin.aumont@gmail.com>
+
+"csc" is the Roslyn C# compiler executable for the Mono project
+(http://www.mono-project.com/). "csc" replaces "mcs" and comes with full
+support for C# 7
+(http://www.mono-project.com/docs/about-mono/releases/5.0.0/#csc). See the
+program's page for details:
+
+    https://github.com/dotnet/roslyn
+
+This checker is based on Daniel Walker's "mcs" checker.
 
 Checker options~
 

--- a/syntax_checkers/cs/csc.vim
+++ b/syntax_checkers/cs/csc.vim
@@ -1,0 +1,39 @@
+"============================================================================
+"File:        csc.vim
+"Description: Syntax checking plugin for syntastic.vim
+"Maintainer:  Martin Aumont <martin.aumont@gmail.com>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"
+"============================================================================
+
+if exists('g:loaded_syntastic_cs_csc_checker')
+    finish
+endif
+let g:loaded_syntastic_cs_csc_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_cs_csc_GetLocList() dict
+    let makeprg = self.makeprgBuild({ 'args_after': '-out:/dev/null' })
+
+    let errorformat = '%f(%l\,%c): %trror %m'
+
+    return SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat,
+        \ 'defaults': {'bufnr': bufnr('')} })
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'cs',
+    \ 'name': 'csc'})
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set sw=4 sts=4 et fdm=marker:


### PR DESCRIPTION
The current C# checker is based on the `mcs` compiler from the Mono project, which is being replaced by the [Roslyn C# compiler](http://www.mono-project.com/docs/about-mono/releases/5.0.0/#csc), whose executable is now called `csc`.

C# 7 code can only be parsed by the new compiler.

This checker is based on the existing `mcs` checker.