### PR TITLE
Fix systemverilog

### DIFF
--- a/doc/syntastic-checkers.txt
+++ b/doc/syntastic-checkers.txt
@@ -107,6 +107,7 @@ SYNTAX CHECKERS BY LANGUAGE                          *syntastic-checkers-lang*
     Solidity.................................|syntastic-checkers-solidity|
     SQL......................................|syntastic-checkers-sql|
     Stylus...................................|syntastic-checkers-stylus|
+    SystemVerilog............................|syntastic-checkers-systemverilog|
 
     Tcl......................................|syntastic-checkers-tcl|
     TeX......................................|syntastic-checkers-tex|
@@ -6770,6 +6771,91 @@ You probably also need a plugin to set |filetype| for Turtle files, such as
     https://github.com/niklasl/vim-rdf
 
 ==============================================================================
+SYNTAX CHECKERS FOR SYSTEMVERILOG           *syntastic-checkers-systemverilog*
+
+The following checkers are available for SystemVerilog (filetype "systemverilog"):
+
+    1. Icarus Verilog...........|syntastic-systemverilog-iverilog|
+    2. Verilator................|syntastic-systemverilog-verilator|
+
+------------------------------------------------------------------------------
+1. Icarus Verilog                           *syntastic-systemverilog-iverilog*
+
+Name:        iverilog
+Maintainer:  Psidium <psiidium@gmail.com>
+
+"Icarus Verilog" is a Verilog simulation and synthesis tool. See the
+project's page for details:
+
+    http://iverilog.icarus.com/
+
+Checker options~
+
+This checker is initialised using the "makeprgBuild()" function and thus it
+accepts the standard options described at |syntastic-config-makeprg|.
+
+------------------------------------------------------------------------------
+2. Verilator                               *syntastic-systemverilog-verilator*
+
+Name:        verilator
+Maintainer:  Kocha <kocha.lsifrontend@gmail.com>
+
+Checker options~
+
+                                        *'g:syntastic_systemverilog_compiler'*
+Type: string
+Default: "verilator"
+Compiler executable.
+
+                                     *'g:syntastic_systemverilog_errorformat'*
+Type: string
+Default: unset
+Override for the default |'errorformat'|.
+
+                           *'g:syntastic_systemverilog_remove_include_errors'*
+Type: boolean
+Default: 0
+By default, errors in files included from the file being checked are shown.
+Set this variable to 1 to remove messages about errors in included files.
+Please note that this means syntastic will silently abort checks if there are
+fatal errors in one of the included files.
+
+                                *'g:syntastic_systemverilog_compiler_options'*
+Type: string
+Default: unset
+Compilation flags (such as defines or include directories) to be passed to the
+linter. Defaults passed: "-Wall +systemverilogext+sv +systemverilogext+svh"
+
+                                     *'g:syntastic_systemverilog_config_file'*
+Type: string
+Default: ".syntastic_verilog_config"
+File containing additional compilation flags to be passed to the linter, one
+option per line (cf. |syntastic-config-files|).
+
+                                    *'g:syntastic_systemverilog_include_dirs'*
+Type: array of strings
+Default: []
+Include directories to be passed to the linter, in addition to the
+above compilation flags. You can set it like this: >
+    let g:syntastic_verilog_include_dirs = ["includes", "headers"]
+<
+and the corresponding "-Iincludes -Iheaders" will be added to the compilation
+flags.
+
+                                          *'b:syntastic_systemverilog_cflags'*
+Type: string
+Default: unset
+Buffer-local variable. Additional compilation flags specific to the current
+buffer.
+
+Note~
+
+This checker doesn't call the "makeprgBuild()" function, and thus it ignores
+the usual 'g:syntastic_verilog_verilator_<option>' variables. The only
+exception is 'g:syntastic_verilog_verilator_exec', which can still be used to
+override the linter's executable.
+
+==============================================================================
 SYNTAX CHECKERS FOR TWIG                             *syntastic-checkers-twig*
 
 The following checkers are available for Twig (filetype "twig"):
@@ -7696,6 +7782,9 @@ syntastic-specific configuration files:
     Objective-C++~
         GCC (|syntastic-objcpp-gcc|)
         OCLint (|syntastic-objcpp-oclint|)
+
+    SystemVerilog~
+        Verilator (|syntastic-systemverilog-verilator|)
 
     Verilog~
         Verilator (|syntastic-verilog-verilator|)

--- a/plugin/syntastic/registry.vim
+++ b/plugin/syntastic/registry.vim
@@ -92,6 +92,7 @@ let s:_DEFAULT_CHECKERS = {
         \ 'solidity':      ['solc'],
         \ 'sql':           ['sqlint'],
         \ 'stylus':        ['stylint'],
+        \ 'systemverilog': ['verilator'],
         \ 'tcl':           ['nagelfar'],
         \ 'tex':           ['lacheck', 'chktex'],
         \ 'texinfo':       ['makeinfo'],

--- a/syntax_checkers/systemverilog/iverilog.vim
+++ b/syntax_checkers/systemverilog/iverilog.vim
@@ -1,0 +1,38 @@
+"============================================================================
+"File:        iverilog.vim
+"Description: Syntax checking plugin for syntastic.vim
+"Maintainer:  Psidium <psiidium at gmail dot com>
+"License:     The MIT License
+"============================================================================
+
+if exists('g:loaded_syntastic_verilog_iverilog_checker')
+    finish
+endif
+let g:loaded_syntastic_verilog_iverilog_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_systemverilog_iverilog_GetLocList() dict
+    let makeprg = self.makeprgBuild({
+        \ 'args_before': '-t null',
+        \ 'args': '-Wall' })
+
+    let errorformat =
+        \ '%f:%l: %trror: %m,' .
+        \ '%f:%l: %tarning: %m,' .
+        \ '%E%f:%l:      : %m,' .
+        \ '%W%f:%l:        : %m,' .
+        \ '%f:%l: %m'
+
+    return SyntasticMake({'makeprg': makeprg, 'errorformat': errorformat})
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'systemverilog',
+    \ 'name': 'iverilog'})
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set sw=4 sts=4 et fdm=marker:

--- a/syntax_checkers/systemverilog/verilator.vim
+++ b/syntax_checkers/systemverilog/verilator.vim
@@ -1,0 +1,42 @@
+"============================================================================
+"File:        verilator.vim
+"Description: Syntax checking plugin for syntastic
+"Maintainer:  Kocha <kocha dot lsifrontend at gmail dot com>
+"============================================================================
+
+if exists('g:loaded_syntastic_systemverilog_verilator_checker')
+    finish
+endif
+let g:loaded_syntastic_systemverilog_verilator_checker = 1
+
+if !exists('g:syntastic_systemverilog_compiler_options')
+    let g:syntastic_systemverilog_compiler_options = '-Wall +systemverilogext+sv +systemverilogext+svh'
+endif
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_systemverilog_verilator_IsAvailable() dict
+    if !exists('g:syntastic_systemverilog_compiler')
+        let g:syntastic_systemverilog_compiler = self.getExec()
+    endif
+    call self.log('g:syntastic_systemverilog_compiler =', g:syntastic_systemverilog_compiler)
+    return executable(expand(g:syntastic_systemverilog_compiler, 1))
+endfunction
+
+function! SyntaxCheckers_systemverilog_verilator_GetLocList() dict
+    return syntastic#c#GetLocList('systemverilog', 'verilator', {
+        \ 'errorformat':
+        \     '%%%trror-%\=%\w%#: %f:%l: %m,' .
+        \     '%%%tarning-%\=%\w%#: %f:%l: %m',
+        \ 'main_flags': '--lint-only' })
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'systemverilog',
+    \ 'name': 'verilator' })
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set sw=4 sts=4 et fdm=marker:


### PR DESCRIPTION
vim at some point folded parts of `ft=systemverilog` into `ft=verilog`, while still setting the different filetype. syntastic was expecting `ft=verilog` for everything. Also, adds sane defaults verilator to use systemverilog instead of plain verilog from 1995. Just works OOTB. 