### PR TITLE
New checker for Solidity: solhint

### DIFF
--- a/doc/syntastic-checkers.txt
+++ b/doc/syntastic-checkers.txt
@@ -6305,6 +6305,7 @@ The following checkers are available for Solidity (filetype "solidity"):
 
     1. solc.....................|syntastic-solidity-solc|
     2. Solium...................|syntastic-solidity-solium|
+    3. Solhint..................|syntastic-solidity-solhint|
 
 ------------------------------------------------------------------------------
 1. solc                                              *syntastic-solidity-solc*
@@ -6338,6 +6339,28 @@ Maintainer:  Matthijs van den Bos <matthijs@vandenbos.org>
 "Solium" is a linter for "Solidity" files. See the project's page for details:
 
     https://github.com/duaraghav8/Solium
+
+Checker options~
+
+This checker is initialised using the "makeprgBuild()" function and thus it
+accepts the standard options described at |syntastic-config-makeprg|.
+
+Note~
+
+You probably also need a plugin to set |filetype| for Solidity files, such as
+"vim-solidity":
+
+    https://github.com/tomlion/vim-solidity
+
+------------------------------------------------------------------------------
+2. Solium                                          *syntastic-solidity-solium*
+
+Name:        solhint
+Maintainer:  Brett Sun <qisheng.brett.sun@gmail.com>
+
+"Solhint" is a linter for "Solidity" files. See the project's page for details:
+
+    https://github.com/protofire/solhint
 
 Checker options~
 

--- a/syntax_checkers/solidity/solhint.vim
+++ b/syntax_checkers/solidity/solhint.vim
@@ -20,9 +20,11 @@ set cpo&vim
 
 function! SyntaxCheckers_solidity_solhint_GetLocList() dict
     let makeprg = self.makeprgBuild({
-        \ 'args_after': '-f unix' })
+        \ 'args_after': '-f compact' })
 
-    let errorformat = '%f:%l:%c: %m'
+    let errorformat =
+        \ '%E%f: line %l\, col %c\, Error - %m,' .
+        \ '%W%f: line %l\, col %c\, Warning - %m'
 
     return SyntasticMake({
         \ 'makeprg': makeprg,

--- a/syntax_checkers/solidity/solhint.vim
+++ b/syntax_checkers/solidity/solhint.vim
@@ -27,6 +27,7 @@ function! SyntaxCheckers_solidity_solhint_GetLocList() dict
     return SyntasticMake({
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat,
+        \ 'subtype': 'Style',
         \ 'returns': [0, 1] })
 endfunction
 

--- a/syntax_checkers/solidity/solhint.vim
+++ b/syntax_checkers/solidity/solhint.vim
@@ -1,0 +1,40 @@
+"============================================================================
+"File:        solhint.vim
+"Description: Solidity syntax checker - using solhint
+"Maintainer:  Brett Sun <qisheng.brett.sun@gmail.com>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"
+"============================================================================
+
+if exists('g:loaded_syntastic_solidity_solhint_checker')
+    finish
+endif
+let g:loaded_syntastic_solidity_solhint_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_solidity_solhint_GetLocList() dict
+    let makeprg = self.makeprgBuild({
+        \ 'args_after': '-f unix' })
+
+    let errorformat = '%f:%l:%c: %m'
+
+    return SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat,
+        \ 'returns': [0, 1] })
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'solidity',
+    \ 'name': 'solhint'})
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set sw=4 sts=4 et fdm=marker:


### PR DESCRIPTION
Based off the existing solium and solc checkers.

The error format string is suboptimal (it captures everything as an error), but I'm not really sure how to fix it right now. `solhint` outputs messages in as `%f:%l:%c: %m [(Error | Warning)/<rule-name>]`, and I can't for the life of me figure out how to make an error format that can parse a message stuck in the middle of the line.

An example output:

```bash
contracts/Payroll.sol:29:3: Explicitly mark visibility of state [Warning/state-visibility]
```

--------

I'll ask solhint if it'd be possible to change it so the error state comes first, but just wanted to check if there was any magic to handle this that I wasn't aware of.