### PR TITLE
Escape commas in the path used in findFileInParent

### DIFF
--- a/autoload/syntastic/util.vim
+++ b/autoload/syntastic/util.vim
@@ -253,7 +253,7 @@ endfunction " }}}2
 function! syntastic#util#findFileInParent(what, where) abort " {{{2
     let old_suffixesadd = &suffixesadd
     let &suffixesadd = ''
-    let file = findfile(a:what, escape(a:where, ' ') . ';')
+    let file = findfile(a:what, escape(a:where, ' ,') . ';')
     let &suffixesadd = old_suffixesadd
     return file
 endfunction " }}}2


### PR DESCRIPTION
findfile() appears to have some undocumented behaviour regarding
commands in the path string. So escape them when we escape spaces.

Closes #2109