### PR TITLE
Add yarac as yara rule syntax checker.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -69,8 +69,9 @@ MATLAB, Mercury, NASM, Nix, Objective-C, Objective-C++, OCaml, Perl, Perl
 NG, reStructuredText, RPM spec, Ruby, SASS/SCSS, Scala, Slim, SML, Solidity,
 Sphinx, SQL, Stylus, Tcl, TeX, Texinfo, Twig, TypeScript, Vala, Verilog, VHDL,
 Vim help, VimL, Vue.js, xHtml, XML, XSLT, XQuery, YACC, YAML, YANG data models,
-z80, Zope page templates, and Zsh. See the [manual][checkers] for details about
-the corresponding supported checkers (`:help syntastic-checkers` in Vim).
+YARA rules, z80, Zope page templates, and Zsh. See the [manual][checkers] for
+details about the corresponding supported checkers (`:help syntastic-checkers`
+in Vim).
 
 A number of third-party Vim plugins also provide checkers for syntastic, for
 example: [merlin][merlin], [omnisharp-vim][omnisharp], [rust.vim][rust],

--- a/doc/syntastic-checkers.txt
+++ b/doc/syntastic-checkers.txt
@@ -132,6 +132,7 @@ SYNTAX CHECKERS BY LANGUAGE                          *syntastic-checkers-lang*
     YACC.....................................|syntastic-checkers-yacc|
     YAML.....................................|syntastic-checkers-yaml|
     YANG.....................................|syntastic-checkers-yang|
+    YARA.....................................|syntastic-checkers-yara|
 
     Z80......................................|syntastic-checkers-z80|
     Zope Page Templates......................|syntastic-checkers-zpt|
@@ -7628,6 +7629,35 @@ You probably also need a plugin to set |filetype| for YANG files, such as
 "yang.vim":
 
     https://github.com/nathanalderson/yang.vim
+
+==============================================================================
+SYNTAX CHECKERS FOR YARA                             *syntastic-checkers-yara*
+
+The following checkers are available for YARA rule files. (filetype "yara"):
+
+    1. yarac....................|syntastic-yara-yarac|
+
+------------------------------------------------------------------------------
+1. yarac                                                *syntastic-yara-yarac*
+
+Name:        yarac
+Maintainer:  Albert Song <albb@teamt5.org>
+
+"yarac" is the official compiler for YARA rule files.
+See the project's page at GitHub for more information:
+
+    https://github.com/VirusTotal/yara
+
+Checker options~
+
+This checker is initialised using the "makeprgBuild()" function and thus it
+accepts the standard options described at |syntastic-config-makeprg|.
+
+Note~
+
+You probably also need to set |filetype| for YARA rule files to "yara".
+You can do that with an `:autocmd`: >
+    autocmd BufNewFile,BufRead *.yar,*.yara set filetype=yara syntax=yara
 
 ==============================================================================
 SYNTAX CHECKERS FOR Z80                               *syntastic-checkers-z80*

--- a/plugin/syntastic/registry.vim
+++ b/plugin/syntastic/registry.vim
@@ -112,6 +112,7 @@ let s:_DEFAULT_CHECKERS = {
         \ 'yacc':          ['bison'],
         \ 'yaml':          ['jsyaml'],
         \ 'yang':          ['pyang'],
+        \ 'yara':          ['yarac'],
         \ 'z80':           ['z80syntaxchecker'],
         \ 'zpt':           ['zptlint'],
         \ 'zsh':           ['zsh'],

--- a/syntax_checkers/yara/yara.vim
+++ b/syntax_checkers/yara/yara.vim
@@ -1,0 +1,41 @@
+"============================================================================
+"File:        yara.vim
+"Description: Syntax checking plugin for syntastic.vim
+"Maintainer:  Albert Song (albb@teamt5.org)
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"
+"============================================================================
+
+if exists('g:loaded_syntastic_yara_yarac_checker')
+    finish
+endif
+let g:loaded_syntastic_yara_yarac_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_yara_yarac_GetLocList() dict
+    let makeprg = self.makeprgBuild({ 'fname_after' : syntastic#util#DevNull() })
+
+    let errorformat =
+            \ '%f(%l): %trror: %m,' .
+            \ '%f(%l): %tarning: %m,'.
+            \ '%f(%l): %m'
+
+    return SyntasticMake({
+	\ 'makeprg': makeprg,
+	\ 'errorformat': errorformat })
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'yara',
+    \ 'name': 'yarac'})
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set sw=4 sts=4 et fdm=marker:


### PR DESCRIPTION
[YARA](https://github.com/VirusTotal/yara) is a widely used pattern matching tool in the malware research field.

This pull request adds support for checking YARA rule syntax by running the official `yarac` compiler.