### PR TITLE
Enable column numbers and warning messages in mypy checker

### DIFF
--- a/autoload/syntastic/preprocess.vim
+++ b/autoload/syntastic/preprocess.vim
@@ -635,9 +635,16 @@ function! syntastic#preprocess#mypy(errors) abort " {{{2
     let out = []
     for e in a:errors
         " new format
-        let parts = matchlist(e, '\v^(.{-1,}):(\d+): error: (.+)')
-        if len(parts) > 3
-            call add(out, join(parts[1:3], ':'))
+        let parts = matchlist(e, '\v^(.{-1,}):(\d+):(\d+:)? (error|warning): (.+)')
+        if len(parts) > 5
+            " strip the last character (the colon) and increment by one
+            let parts[3] = string(str2nr(parts[3][:-2]) + 1)
+            let parts[4] = parts[4][0]
+            call add(out, join(parts[1:5], ':'))
+            continue
+        elseif len(parts) > 4
+            let parts[3] = parts[3][0]
+            call add(out, join(parts[1:4], ':'))
             continue
         endif
 

--- a/syntax_checkers/python/mypy.vim
+++ b/syntax_checkers/python/mypy.vim
@@ -15,13 +15,12 @@ set cpo&vim
 
 function! SyntaxCheckers_python_mypy_GetLocList() dict
     let makeprg = self.makeprgBuild({})
-
-    let errorformat = '%f:%l:%m'
+    " the below format is the result of preprocessing
+    let errorformat = '%f:%l:%c:%t:%m'
 
     return SyntasticMake({
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat,
-        \ 'defaults': { 'type': 'E' },
         \ 'returns': [0, 1],
         \ 'preprocess': 'mypy' })
 endfunction


### PR DESCRIPTION
The preprocessing of the mypy's output, as well as its errorformat,
have been changed, so that the column numbers
and message severity are properly included.

The 'note:' lines are not taken into account and are skipped.