### PR TITLE
Fix go vet output parsing for go >= 1.10.

### DIFF
--- a/syntax_checkers/go/govet.vim
+++ b/syntax_checkers/go/govet.vim
@@ -24,6 +24,7 @@ function! SyntaxCheckers_go_govet_GetLocList() dict
 
     let errorformat =
         \ '%Evet: %.%\+: %f:%l:%c: %m,' .
+        \ '%f:%l:%c: %m,' .
         \ '%W%f:%l: %m,' .
         \ '%-G%.%#'
 


### PR DESCRIPTION
- Changed errorformat of go vet to include go build style messages in
  the parsing of go vet invocations.
- With go 1.10, govet apparently now runs a "go build" to collect
  information about the entire project. As a result, go vet will
  now output both go build and go vet errors. Previously, only
  go vet specific errors were reported.