### PR TITLE
Fix puppet 5 parser

### DIFF
--- a/syntax_checkers/puppet/puppet.vim
+++ b/syntax_checkers/puppet/puppet.vim
@@ -30,7 +30,8 @@ function! SyntaxCheckers_puppet_puppet_GetLocList() dict
         \ '%-Gerr: Try ''puppet help parser validate'' for usage,' .
         \ '%-GError: Try ''puppet help parser validate'' for usage,' .
         \ '%A%t%*[a-zA-Z]: %m at %f:%l:%c,' .
-        \ '%A%t%*[a-zA-Z]: %m at %f:%l'
+        \ '%A%t%*[a-zA-Z]: %m at %f:%l,'.
+        \ '%AError: Could not parse for environment production: %m (file: %f\, line: %l\, column: %c)'
 
     return SyntasticMake({
         \ 'makeprg': makeprg,


### PR DESCRIPTION
  The new (not so new now) version of pupper (5) change a little the
parser output. Now it's something like

  Error: Could not parse for environment production: Syntax error at 'group' (file: /manifests/homedir.pp, line: 16, column: 5)

this bad fix allow syntastic to still working with puppet 5.

Currently puppet parser got a option (--render-as) to allow (well should) to create to ouput of the parser as json/yaml but still not working. Maybe some day...