### PR TITLE
[clang-tidy] [clang-check] Correctly pass args

### DIFF
--- a/syntax_checkers/c/clang_check.vim
+++ b/syntax_checkers/c/clang_check.vim
@@ -28,13 +28,12 @@ set cpo&vim
 function! SyntaxCheckers_c_clang_check_GetLocList() dict
     let makeprg = self.makeprgBuild({
         \ 'post_args':
-        \   '-- ' .
         \   syntastic#c#ReadConfig(g:syntastic_clang_check_config_file) . ' ' .
-        \   '-fshow-column ' .
-        \   '-fshow-source-location ' .
-        \   '-fno-caret-diagnostics ' .
-        \   '-fno-color-diagnostics ' .
-        \   '-fdiagnostics-format=clang' })
+        \   '-extra-arg=-fshow-column ' .
+        \   '-extra-arg=-fshow-source-location ' .
+        \   '-extra-arg=-fno-caret-diagnostics ' .
+        \   '-extra-arg=-fno-color-diagnostics ' .
+        \   '-extra-arg=-fdiagnostics-format=clang' })
 
     let errorformat =
         \ '%E%f:%l:%c: fatal error: %m,' .

--- a/syntax_checkers/c/clang_tidy.vim
+++ b/syntax_checkers/c/clang_tidy.vim
@@ -28,13 +28,12 @@ set cpo&vim
 function! SyntaxCheckers_c_clang_tidy_GetLocList() dict
     let makeprg = self.makeprgBuild({
         \ 'post_args':
-        \   '-- ' .
         \   syntastic#c#ReadConfig(g:syntastic_clang_tidy_config_file) . ' ' .
-        \   '-fshow-column ' .
-        \   '-fshow-source-location ' .
-        \   '-fno-caret-diagnostics ' .
-        \   '-fno-color-diagnostics ' .
-        \   '-fdiagnostics-format=clang' })
+        \   '-extra-arg=-fshow-column ' .
+        \   '-extra-arg=-fshow-source-location ' .
+        \   '-extra-arg=-fno-caret-diagnostics ' .
+        \   '-extra-arg=-fno-color-diagnostics ' .
+        \   '-extra-arg=-fdiagnostics-format=clang' })
 
     let errorformat =
         \ '%E%f:%l:%c: fatal error: %m,' .


### PR DESCRIPTION
Passing the arguments like it was done is not documented and seems to
even override any options, this means that clang is in fact only invoked
with said options, which not only suppresses warnings but also ignores
input from compile_commands.json etc. including include directories.

The correct way to pass arguments to clang is to use -extra-arg=<arg>.