### PR TITLE
Missing bracket added in cuda checker (nvcc)

### DIFF
--- a/syntax_checkers/cuda/nvcc.vim
+++ b/syntax_checkers/cuda/nvcc.vim
@@ -37,7 +37,7 @@ function! SyntaxCheckers_cuda_nvcc_GetLocList() dict
 
     call extend(build_opts, {
         \ 'args_before': arch_flag . ' --cuda -O0 -I .',
-        \ 'args': syntastic#c#ReadConfig(syntastic#util#bufVar(buf, 'cuda_config_file'),
+        \ 'args': syntastic#c#ReadConfig(syntastic#util#bufVar(buf, 'cuda_config_file')),
         \ 'args_after': '-Xcompiler -fsyntax-only',
         \ 'tail_after': syntastic#c#NullOutput() })
 


### PR DESCRIPTION
# Problem
Related Issue: https://github.com/vim-syntastic/syntastic/issues/2174
Problem: Missing bracket causes error on startup

# Proposed solution
Add bracket in nvcc.vim, changing
https://github.com/vim-syntastic/syntastic/blob/e53722e61d68aae278d75191038c6fda3777f3d5/syntax_checkers/cuda/nvcc.vim#L40
to 
https://github.com/derpda/syntastic/blob/e53722e61d68aae278d75191038c6fda3777f3d5/syntax_checkers/cuda/nvcc.vim#L40

This should resolve #2174 


# PS
This is my first pull request ever, please let me know anything I should have done differently!
