### PR TITLE
Fix prospector checker (Python3 compat)

### DIFF
--- a/syntax_checkers/python/prospector.vim
+++ b/syntax_checkers/python/prospector.vim
@@ -31,7 +31,7 @@ endfunction
 
 function! SyntaxCheckers_python_prospector_GetLocList() dict
     let makeprg = self.makeprgBuild({
-        \ 'args_after': '--messages-only --absolute-paths --die-on-tool-error --zero-exit --output-format json' })
+        \ 'args_after': '--messages-only --absolute-paths --die-on-tool-error --zero-exit --output-format json 2>' . syntastic#util#DevNull()})
 
     let errorformat = '%f:%l:%c: %m'
 


### PR DESCRIPTION
The Python 3.x version of prospector sends some junk to stderr.
Simply redirecting stderr to DevNull solves issue.