### PR TITLE
disable generate binary file when syntastic go file

### DIFF
--- a/syntax_checkers/go/go.vim
+++ b/syntax_checkers/go/go.vim
@@ -60,7 +60,7 @@ function! SyntaxCheckers_go_go_GetLocList() dict
         let cleanup = 1
     else
         let cmd = 'build'
-        let opts = syntastic#util#bufVar(buf, 'go_go_build_args', s:go_new ? '-buildmode=default' : '')
+        let opts = syntastic#util#bufVar(buf, 'go_go_build_args', s:go_new ? '-buildmode=default -o=/dev/null' : '')
         let cleanup = 0
     endif
     let opt_str = (type(opts) != type('') || opts !=# '') ? join(syntastic#util#argsescape(opts)) : opts


### PR DESCRIPTION
Currently, each time when syntastic a go file using the default `go build mode`, it'll generate a binary file in the current folder,  which is annoying when using versioning tool like git.

Adding a `-o=/dev/null` will redirect it to /dev/null, more clear.