### PR TITLE
mypy: ignore missing imports

### DIFF
--- a/syntax_checkers/python/mypy.vim
+++ b/syntax_checkers/python/mypy.vim
@@ -20,7 +20,7 @@ function! SyntaxCheckers_python_mypy_GetLocList() dict
         let s:mypy_new = syntastic#util#versionIsAtLeast(self.getVersion(), [0, 4, 5])
     endif
 
-    let makeprg = self.makeprgBuild({ 'args_after': (s:mypy_new ? '--show-column-numbers' : '') })
+    let makeprg = self.makeprgBuild({ 'args_after': (s:mypy_new ? '--show-column-numbers --ignore-missing-imports' : '') })
 
     let errorformat =
         \ '%f:%l:%c:%t:%m,' .


### PR DESCRIPTION
Importing stubless libraries fills up the bottom window with
module not found errors. `--ignore-missing-imports` flag
removes those messages allowing users to see issues
with their code.