### PR TITLE
Adding remark-lint

### DIFF
--- a/syntax_checkers/markdown/remark_lint.vim
+++ b/syntax_checkers/markdown/remark_lint.vim
@@ -24,7 +24,8 @@ function! SyntaxCheckers_markdown_remark_lint_GetLocList() dict
           \'args_before': '--quiet --no-stdout --no-color' })
 
     let errorformat =
-        \ '  %l:%c  %tarning  %m'
+        \ '%\s%#%l:%c%\s%#%tarning  %m  remark-lint,' .
+        \ '%\s%#%l:%c-%.%#%\s%#%tarning  %m  remark-lint'
 
     return SyntasticMake({
         \ 'makeprg': makeprg,

--- a/syntax_checkers/markdown/remark_lint.vim
+++ b/syntax_checkers/markdown/remark_lint.vim
@@ -1,0 +1,44 @@
+"============================================================================
+"File:        remark.vim
+"Description: Syntax checking plugin for syntastic using remark-lint
+"             (https://github.com/remarkjs/remark-lint)
+"Maintainer:  Tim Carry <tim at pixelastic dot com>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"
+"============================================================================
+
+if exists('g:loaded_syntastic_markdown_remark_lint_checker')
+    finish
+endif
+let g:loaded_syntastic_markdown_remark_lint_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_markdown_remark_lint_GetLocList() dict
+    let makeprg = self.makeprgBuild({ 
+          \'args_before': '--quiet --no-stdout --no-color' })
+
+    let errorformat =
+        \ '  %l:%c  %tarning  %m'
+
+    return SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat,
+        \ 'defaults': {'bufnr': bufnr('')},
+        \ 'returns': [0] })
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'markdown',
+    \ 'name': 'remark_lint',
+    \ 'exec': 'remark'})
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set sw=4 sts=4 et fdm=marker:


### PR DESCRIPTION
Hello,

I added a checker for parsing markdown through [remark-lint](https://github.com/remarkjs/remark-lint) (itself based on [remark](https://github.com/remarkjs/remark/tree/master/packages/remark-cli)).

It expects `remark` to be globally available [as a CLI tool](https://github.com/remarkjs/remark/tree/master/packages/remark-cli) and configured to use `remark-lint` by creating a `.remarkrc.js` similar to this one:
```javascript
exports.plugins = [
  'remark-preset-lint-recommended',
];
```

The `--no-stdout` prevents it from displaying the whole file in stdout. `--quiet` is supposed to only display warnings and errors, but I didn't see it having any impact when used with `--no-stdout`. I decided to keep it, just in case.

Output looks something like this:
![image](https://user-images.githubusercontent.com/283419/44467492-4666ab80-a623-11e8-99ee-16e162b12e72.png)

I'm still no `errorformat` expert and I couldn't find a way to extract the file name (on its own line). So I cheated by setting a default `bufnr`. The checker surely has other rough edges; looking forward to see your patch on top of it to make it better @lcd047.

_Note that I checked the [Syntax Checker Guide](https://github.com/vim-syntastic/syntastic/wiki/Syntax-Checker-Guide), mentioning that no new checker would be accepted until the API stabilized. But last update of this page is dating from 2016 so I assumed it has been stabilized since._


