### PR TITLE
In Ada, syntastic should check .ads files too

### DIFF
--- a/syntax_checkers/ada/gcc.vim
+++ b/syntax_checkers/ada/gcc.vim
@@ -33,8 +33,7 @@ function! SyntaxCheckers_ada_gcc_GetLocList() dict
         \     '%f:%l:%c: %m,' .
         \     '%f:%l: %m',
         \ 'main_flags': '-c -x ada -gnats -gnatef',
-        \ 'header_flags': '-x ada -gnats -gnatef',
-        \ 'header_names': '\.ads$' })
+        \ 'header_flags': '-x ada -gnats -gnatef' })
 endfunction
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({


### PR DESCRIPTION
Hi,

It took me a while to realize that syntastic was not checking syntax in .ads files for Ada.
However, gcc is perfectly happy to handle those files, and it is convenient to have the
information immediately in vim.

Thanks
Emmanuel