### PR TITLE
checkpatch: Catch strict warnings

### DIFF
--- a/syntax_checkers/c/checkpatch.vim
+++ b/syntax_checkers/c/checkpatch.vim
@@ -39,6 +39,7 @@ function! SyntaxCheckers_c_checkpatch_GetLocList() dict
     let makeprg = self.makeprgBuild({ 'args_after': '--no-summary --no-tree --terse --file' })
 
     let errorformat =
+        \ '%W%f:%l: CHECK: %m,' .
         \ '%f:%l: %tARNING: %m,' .
         \ '%f:%l: %tRROR: %m'
 


### PR DESCRIPTION
When the "--strict" or "--subjective" options are added to checkpatch's
arguments, it will return additional warnings of this format type:

> file.c:123: CHECK: Alignment should match open parenthesis

The extra warnings can be enabled with:

> let g:syntastic_c_checkpatch_args = "--strict"

Signed-off-by: Brandon Maier <brandon.maier@rockwellcollins.com>