### PR TITLE
checkpatch: Enable tree checking if available

### DIFF
--- a/doc/syntastic-checkers.txt
+++ b/doc/syntastic-checkers.txt
@@ -579,6 +579,15 @@ Checker options~
 This checker is initialised using the "makeprgBuild()" function and thus it
 accepts the standard options described at |syntastic-config-makeprg|.
 
+Additionally:
+
+                                            *'g:syntastic_c_checkpatch_tree'*
+Type: boolean
+Default: unset
+When set to '0', will call checkpatch with '--no-tree' which disables warnings
+that require the full Linux source tree to run. If unset, Syntastic will
+attempt to autodetect if tree is available.
+
 ------------------------------------------------------------------------------
 3. ClangCheck                                        *syntastic-c-clang_check*
 

--- a/syntax_checkers/c/checkpatch.vim
+++ b/syntax_checkers/c/checkpatch.vim
@@ -36,7 +36,13 @@ function! SyntaxCheckers_c_checkpatch_IsAvailable() dict
 endfunction
 
 function! SyntaxCheckers_c_checkpatch_GetLocList() dict
-    let makeprg = self.makeprgBuild({ 'args_after': '--no-summary --no-tree --terse --file' })
+
+    if !exists('g:syntastic_c_checkpatch_tree')
+        silent! call syntastic#util#system(self.getExec() . ' </dev/null')
+        let g:syntastic_c_checkpatch_tree = v:shell_error ? 0 : 1
+    endif
+
+    let makeprg = self.makeprgBuild({ 'args_after': '--no-summary --terse --file' . (g:syntastic_c_checkpatch_tree ? '' : ' --no-tree') })
 
     let errorformat =
         \ '%W%f:%l: CHECK: %m,' .


### PR DESCRIPTION
If checkpatch has access to a Linux source tree, it can find additional
warnings. Add a new option to let users manually enable/disable the
'--no-tree' option. If no selection is made, attempt to autodetect tree
support.

Signed-off-by: Brandon Maier <brandon.maier@rockwellcollins.com>