### PR TITLE
Implemented basic Zig syntax checker.

### DIFF
--- a/plugin/syntastic/registry.vim
+++ b/plugin/syntastic/registry.vim
@@ -114,6 +114,7 @@ let s:_DEFAULT_CHECKERS = {
         \ 'yang':          ['pyang'],
         \ 'yara':          ['yarac'],
         \ 'z80':           ['z80syntaxchecker'],
+        \ 'zig':           ['zig'],
         \ 'zpt':           ['zptlint'],
         \ 'zsh':           ['zsh'],
     \ }

--- a/syntax_checkers/zig/zig.vim
+++ b/syntax_checkers/zig/zig.vim
@@ -1,0 +1,32 @@
+if exists('g:loaded_syntastic_zig_zig_checker')
+    finish
+endif
+let g:loaded_syntastic_zig_zig_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_zig_zig_IsAvailable() dict
+    return executable(self.getExec())
+endfunction
+
+function! SyntaxCheckers_zig_zig_GetLocList() dict
+    let makeprg = self.makeprgBuild({
+                \ 'exe_after': 'build', 
+                \ 'fname': '' })
+    let errorformat = '%f:%l:%c: %m'
+    let loclist = SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat,
+        \ 'env': {} })
+    return loclist
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+            \ 'filetype': 'zig',
+            \ 'name':     'zig' })
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set sw=4 sts=4 et fdm=marker:


### PR DESCRIPTION
Implemented a very simple checker for the [Zig language].

Implementation currently invokes "Zig Build" and thus depends on using a Zig buildfile.

Does not yet support GetHighlightRegex.