### PR TITLE
Checker ansible/ansible_lint: fix errorformat

### DIFF
--- a/syntax_checkers/ansible/ansible_lint.vim
+++ b/syntax_checkers/ansible/ansible_lint.vim
@@ -29,6 +29,7 @@ function! SyntaxCheckers_ansible_ansible_lint_GetLocList() dict
     let makeprg = self.makeprgBuild({ 'args_after': '-p' })
 
     let errorformat =
+        \ '%f:%l: [E%n] %m,' .
         \ '%f:%l: [EANSIBLE%n] %m,' .
         \ '%f:%l: [ANSIBLE%n] %m'
 


### PR DESCRIPTION
ansible-lint now has a slightly different outputformat for errors:

```
prepare-host.yaml:24: [E302] chmod used in place of argument mode to
file module
```

Append the errorformat so this gets recognized by syntastic.