### PR TITLE
Add validator.nu checkers for XHTML and SVG

### DIFF
--- a/doc/syntastic-checkers.txt
+++ b/doc/syntastic-checkers.txt
@@ -107,6 +107,7 @@ SYNTAX CHECKERS BY LANGUAGE                          *syntastic-checkers-lang*
     Solidity.................................|syntastic-checkers-solidity|
     SQL......................................|syntastic-checkers-sql|
     Stylus...................................|syntastic-checkers-stylus|
+    SVG......................................|syntastic-checkers-svg|
 
     Tcl......................................|syntastic-checkers-tcl|
     TeX......................................|syntastic-checkers-tex|
@@ -6562,6 +6563,86 @@ Note~
 You might also find useful the "vim-stylus" plugin:
 
     https://github.com/wavded/vim-stylus
+
+==============================================================================
+SYNTAX CHECKERS FOR SVG                               *syntastic-checkers-svg*
+
+The following checkers are available for SVG (filetype "svg"):
+
+    1. validator................|syntastic-svg-validator|
+
+------------------------------------------------------------------------------
+1. Validator                                         *syntastic-svg-validator*
+
+Name:        validator
+Maintainer:  LCD 47 <lcd047@gmail.com>
+
+"Validator" is a non-DTD-based HTML linter.  See the project's page for
+details:
+
+    https://validator.github.io/validator/
+
+As a syntastic linter, you can validate your files against the online service
+(see https://validator.nu/), or you can install "vnu.jar":
+
+    https://github.com/validator/validator/releases/latest
+
+then run it as a HTTP server: >
+    $ java -Xss512k -cp /path/to/vnu.jar nu.validator.servlet.Main 8888
+<
+Requirement~
+
+This checker uses cURL:
+
+    http://curl.haxx.se/
+
+Checker options~
+
+                                             *'g:syntastic_svg_validator_api'*
+Type: string
+Default: "https://validator.nu/"
+URL of the service to use for checking. Leave it to the default to run the
+checks against "https://validator.nu/", or set it to "http://localhost:8888/"
+if you have "vnu.jar" installed, and you're running it as a standalone HTTP
+server. See:
+
+    https://validator.github.io/validator/#standalone
+
+                                          *'g:syntastic_svg_validator_parser'*
+Type: string
+Default: empty
+Parser to use. Legal values are: "xml", "xmldtd", "html", "html5", "html4",
+and "html4tr". Set it to "html5" to check HTML5 files. References:
+
+    https://wiki.whatwg.org/wiki/Validator.nu_Common_Input_Parameters#parser
+
+                                        *'g:syntastic_svg_validator_nsfilter'*
+Type: string
+Default: empty
+Sets the "nsfilter" for the parser. See:
+
+    https://wiki.whatwg.org/wiki/Validator.nu_Common_Input_Parameters#nsfilter
+
+                                            *'g:syntastic_svg_validator_exec'*
+Type: string
+Default: "curl"
+Path to the "cURL" executable. Override it with a full path if your "cURL" is
+not installed in a standard location.
+
+This checker doesn't call the "makeprgBuild()" function, and thus it ignores
+the usual 'g:syntastic_svg_validator_<option>' variables. The only exception
+is 'g:syntastic_svg_validator_exec', which can be used to override the path
+to the "cURL" executable.
+
+Note~
+
+Non-zero exit codes from "cURL" are typically network errors, and are signaled
+by syntastic with messages such as: >
+    syntastic: error: checker svg/validator returned abnormal status 26
+<
+You can lookup the meaning of these codes in cURL's manual:
+
+    https://curl.haxx.se/docs/manpage.html#EXIT
 
 ==============================================================================
 SYNTAX CHECKERS FOR TCL                               *syntastic-checkers-tcl*

--- a/doc/syntastic-checkers.txt
+++ b/doc/syntastic-checkers.txt
@@ -7375,6 +7375,7 @@ The following checkers are available for xHTML (filetype "xhtml"):
     1. HTML Tidy................|syntastic-xhtml-tidy|
     2. jshint...................|syntastic-xhtml-jshint|
     3. proselint................|syntastic-xhtml-proselint|
+    4. validator................|syntastic-xhtml-validator|
 
 ------------------------------------------------------------------------------
 1. HTML tidy                                            *syntastic-xhtml-tidy*
@@ -7469,6 +7470,79 @@ See also: |syntastic-asciidoc-proselint|, |syntastic-help-proselint|,
 |syntastic-nroff-proselint|, |syntastic-pod-proselint|,
 |syntastic-rst-proselint|, |syntastic-tex-proselint|,
 |syntastic-texinfo-proselint|, |syntastic-text-proselint|.
+
+------------------------------------------------------------------------------
+4. Validator                                       *syntastic-xhtml-validator*
+
+Name:        validator
+Maintainer:  LCD 47 <lcd047@gmail.com>
+
+"Validator" is a non-DTD-based HTML linter.  See the project's page for
+details:
+
+    https://validator.github.io/validator/
+
+As a syntastic linter, you can validate your files against the online service
+(see https://validator.nu/), or you can install "vnu.jar":
+
+    https://github.com/validator/validator/releases/latest
+
+then run it as a HTTP server: >
+    $ java -Xss512k -cp /path/to/vnu.jar nu.validator.servlet.Main 8888
+<
+Requirement~
+
+This checker uses cURL:
+
+    http://curl.haxx.se/
+
+Checker options~
+
+                                           *'g:syntastic_xhtml_validator_api'*
+Type: string
+Default: "https://validator.nu/"
+URL of the service to use for checking. Leave it to the default to run the
+checks against "https://validator.nu/", or set it to "http://localhost:8888/"
+if you have "vnu.jar" installed, and you're running it as a standalone HTTP
+server. See:
+
+    https://validator.github.io/validator/#standalone
+
+                                        *'g:syntastic_xhtml_validator_parser'*
+Type: string
+Default: empty
+Parser to use. Legal values are: "xml", "xmldtd", "html", "html5", "html4",
+and "html4tr". Set it to "html5" to check HTML5 files. References:
+
+    https://wiki.whatwg.org/wiki/Validator.nu_Common_Input_Parameters#parser
+
+                                      *'g:syntastic_xhtml_validator_nsfilter'*
+Type: string
+Default: empty
+Sets the "nsfilter" for the parser. See:
+
+    https://wiki.whatwg.org/wiki/Validator.nu_Common_Input_Parameters#nsfilter
+
+                                          *'g:syntastic_xhtml_validator_exec'*
+Type: string
+Default: "curl"
+Path to the "cURL" executable. Override it with a full path if your "cURL" is
+not installed in a standard location.
+
+This checker doesn't call the "makeprgBuild()" function, and thus it ignores
+the usual 'g:syntastic_xhtml_validator_<option>' variables. The only exception
+is 'g:syntastic_xhtml_validator_exec', which can be used to override the path
+to the "cURL" executable.
+
+Note~
+
+Non-zero exit codes from "cURL" are typically network errors, and are signaled
+by syntastic with messages such as: >
+    syntastic: error: checker xhtml/validator returned abnormal status 26
+<
+You can lookup the meaning of these codes in cURL's manual:
+
+    https://curl.haxx.se/docs/manpage.html#EXIT
 
 ==============================================================================
 SYNTAX CHECKERS FOR XML                               *syntastic-checkers-xml*

--- a/syntax_checkers/html/validator.vim
+++ b/syntax_checkers/html/validator.vim
@@ -35,6 +35,7 @@ function! SyntaxCheckers_html_validator_GetLocListForType(exec_escaped, type)
     let fname = syntastic#util#shescape(fnamemodify(bufname(buf), ':p'))
     let media_type =
         \ a:type ==# 'html' ? 'text/html' :
+        \ a:type ==# 'xhtml' ? 'application/xhtml+xml' :
         \ ''
     let makeprg = a:exec_escaped . ' -q -L -s --compressed -F out=gnu -F asciiquotes=yes' .
         \ (g:syntastic_{a:type}_validator_parser !=# '' ? ' -F parser=' . g:syntastic_{a:type}_validator_parser : '') .

--- a/syntax_checkers/html/validator.vim
+++ b/syntax_checkers/html/validator.vim
@@ -30,13 +30,16 @@ endif
 let s:save_cpo = &cpo
 set cpo&vim
 
-function! SyntaxCheckers_html_validator_GetLocList() dict
+function! SyntaxCheckers_html_validator_GetLocListForType(exec_escaped, type)
     let buf = bufnr('')
     let fname = syntastic#util#shescape(fnamemodify(bufname(buf), ':p'))
-    let makeprg = self.getExecEscaped() . ' -q -L -s --compressed -F out=gnu -F asciiquotes=yes' .
-        \ (g:syntastic_html_validator_parser !=# '' ? ' -F parser=' . g:syntastic_html_validator_parser : '') .
-        \ (g:syntastic_html_validator_nsfilter !=# '' ? ' -F nsfilter=' . g:syntastic_html_validator_nsfilter : '') .
-        \ ' -F doc=@' . fname . '\;type=text/html\;filename=' . fname . ' ' . g:syntastic_html_validator_api
+    let media_type =
+        \ a:type ==# 'html' ? 'text/html' :
+        \ ''
+    let makeprg = a:exec_escaped . ' -q -L -s --compressed -F out=gnu -F asciiquotes=yes' .
+        \ (g:syntastic_{a:type}_validator_parser !=# '' ? ' -F parser=' . g:syntastic_{a:type}_validator_parser : '') .
+        \ (g:syntastic_{a:type}_validator_nsfilter !=# '' ? ' -F nsfilter=' . g:syntastic_{a:type}_validator_nsfilter : '') .
+        \ ' -F doc=@' . fname . (media_type !=# '' ? '\;type=' . media_type : '') . '\;filename=' . fname . ' ' . g:syntastic_{a:type}_validator_api
 
     let errorformat =
         \ '%E"%f":%l: %trror: %m,' .
@@ -57,6 +60,10 @@ function! SyntaxCheckers_html_validator_GetLocList() dict
         \ 'errorformat': errorformat,
         \ 'preprocess': 'validator',
         \ 'returns': [0] })
+endfunction
+
+function! SyntaxCheckers_html_validator_GetLocList() dict
+    return SyntaxCheckers_html_validator_GetLocListForType(self.getExecEscaped(), 'html')
 endfunction
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({

--- a/syntax_checkers/html/validator.vim
+++ b/syntax_checkers/html/validator.vim
@@ -35,6 +35,7 @@ function! SyntaxCheckers_html_validator_GetLocListForType(exec_escaped, type)
     let fname = syntastic#util#shescape(fnamemodify(bufname(buf), ':p'))
     let media_type =
         \ a:type ==# 'html' ? 'text/html' :
+        \ a:type ==# 'svg' ? 'image/svg+xml' :
         \ a:type ==# 'xhtml' ? 'application/xhtml+xml' :
         \ ''
     let makeprg = a:exec_escaped . ' -q -L -s --compressed -F out=gnu -F asciiquotes=yes' .

--- a/syntax_checkers/svg/validator.vim
+++ b/syntax_checkers/svg/validator.vim
@@ -1,0 +1,47 @@
+"============================================================================
+"File:        validator.vim
+"Description: Syntax checking plugin for syntastic
+"Maintainer:  LCD 47 <lcd047 at gmail dot com>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"
+"============================================================================
+
+if exists('g:loaded_syntastic_svg_validator_checker')
+    finish
+endif
+let g:loaded_syntastic_svg_validator_checker=1
+
+if !exists('g:syntastic_svg_validator_api')
+    let g:syntastic_svg_validator_api = 'https://validator.nu/'
+endif
+
+if !exists('g:syntastic_svg_validator_parser')
+    let g:syntastic_svg_validator_parser = ''
+endif
+
+if !exists('g:syntastic_svg_validator_nsfilter')
+    let g:syntastic_svg_validator_nsfilter = ''
+endif
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_svg_validator_GetLocList() dict
+    return SyntaxCheckers_html_validator_GetLocListForType(self.getExecEscaped(), 'svg')
+endfunction
+
+runtime! syntax_checkers/html/validator.vim
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'svg',
+    \ 'name': 'validator',
+    \ 'exec': 'curl' })
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set sw=4 sts=4 et fdm=marker:

--- a/syntax_checkers/xhtml/validator.vim
+++ b/syntax_checkers/xhtml/validator.vim
@@ -1,0 +1,47 @@
+"============================================================================
+"File:        validator.vim
+"Description: Syntax checking plugin for syntastic
+"Maintainer:  LCD 47 <lcd047 at gmail dot com>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"
+"============================================================================
+
+if exists('g:loaded_syntastic_xhtml_validator_checker')
+    finish
+endif
+let g:loaded_syntastic_xhtml_validator_checker=1
+
+if !exists('g:syntastic_xhtml_validator_api')
+    let g:syntastic_xhtml_validator_api = 'https://validator.nu/'
+endif
+
+if !exists('g:syntastic_xhtml_validator_parser')
+    let g:syntastic_xhtml_validator_parser = ''
+endif
+
+if !exists('g:syntastic_xhtml_validator_nsfilter')
+    let g:syntastic_xhtml_validator_nsfilter = ''
+endif
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_xhtml_validator_GetLocList() dict
+    return SyntaxCheckers_html_validator_GetLocListForType(self.getExecEscaped(), 'xhtml')
+endfunction
+
+runtime! syntax_checkers/html/validator.vim
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'xhtml',
+    \ 'name': 'validator',
+    \ 'exec': 'curl' })
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set sw=4 sts=4 et fdm=marker:


### PR DESCRIPTION
The [validator.nu](https://validator.nu) service supports XHTML and SVG in addition to HTML.  This pull request refactors html/validator so that the API calling logic can be shared, then adds checkers for XHTML and SVG by calling the shared function.  Let me know what you think.

Thanks for considering,
Kevin