### PR TITLE
Checker php/phpstan: fix errorformat option (BC break in PHPStan 0.11)

### DIFF
--- a/syntax_checkers/php/phpstan.vim
+++ b/syntax_checkers/php/phpstan.vim
@@ -29,7 +29,7 @@ function! SyntaxCheckers_php_phpstan_GetLocList() dict
     let makeprg = self.makeprgBuild({
         \ 'exe_after': 'analyse',
         \ 'args': '--level=5',
-        \ 'args_after': '--errorFormat raw' })
+        \ 'args_after': '--error-format raw' })
 
     let errorformat = '%f:%l:%m'
 


### PR DESCRIPTION
PHPStan version 0.11 changes the command-line flag from `--errorFormat` to `--error-format`.  That change makes the checker unusable.

This PR fixes it.