### PR TITLE
Fix typo in eslint syntax_checker

### DIFF
--- a/syntax_checkers/javascript/eslint.vim
+++ b/syntax_checkers/javascript/eslint.vim
@@ -42,7 +42,7 @@ function! SyntaxCheckers_javascript_eslint_GetLocList() dict
             \ "'--config ' . syntastic#util#shexpand(OLD_VAR)")
     endif
 
-    let makeprg = self.makeprgBuild({ 'args_before': (g:syntastic_javascript_eslint_generic ? '' : '-f compact') })
+    let makeprg = self.makeprgBuild({ 'args_before': (g:syntastic_javascript_eslint_generic ? '' : '-f --compact') })
 
     let errorformat =
         \ '%E%f: line %l\, col %c\, Error - %m,' .


### PR DESCRIPTION
When defining `makeprg` with `g:syntactic_javascrit_eslint_generic=0`, the added `compact` option is missing the `--` prefix.