### PR TITLE
Update perl6 checker for 6.d

### DIFF
--- a/doc/syntastic-checkers.txt
+++ b/doc/syntastic-checkers.txt
@@ -4851,6 +4851,13 @@ You can also set the "PERL6LIB" environment variable to a colon-separated
 list of add-hoc include paths. These paths will then be added to the ones
 prescribed by |'g:syntastic_perl6_lib_path'|.
 
+                                     *'g:syntastic_perl6_enviroment_variable'*
+Type: string 
+Default: "PERL6_EXCEPTIONS_HANDLER"
+If the Rakudo compiler version is before version 2018.08
+(https://docs.perl6.org/programs/03-environment-variables):
+   `let g:syntastic_perl6_enviroment_variable = "RAKUDO_EXCEPTIONS_HANDLER"`
+
 Note~
 
 At the time of this writing the support for JSON error output of the "Rakudo"

--- a/syntax_checkers/perl6/perl6.vim
+++ b/syntax_checkers/perl6/perl6.vim
@@ -25,11 +25,24 @@
 " Reference:
 "
 " - https://docs.perl6.org/programs/00-running
+"
+" If the Rakudo compiler version is before version 2018.08:
+"
+"   let g:syntastic_perl6_enviroment_variable = "RAKUDO_EXCEPTIONS_HANDLER"
+"
+" Reference:
+"
+" - https://docs.perl6.org/programs/03-environment-variables.html
+"
 
 if exists('g:loaded_syntastic_perl6_perl6_checker')
     finish
 endif
 let g:loaded_syntastic_perl6_perl6_checker = 1
+
+if !exists('g:syntastic_perl6_enviroment_variable')
+    let g:syntastic_perl6_enviroment_variable="PERL6_EXCEPTIONS_HANDLER"
+endif
 
 if !exists('g:syntastic_perl6_lib_path')
     let g:syntastic_perl6_lib_path = []
@@ -88,7 +101,7 @@ function! SyntaxCheckers_perl6_perl6_GetLocList() dict " {{{1
     return SyntasticMake({
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat,
-        \ 'env': { 'RAKUDO_EXCEPTIONS_HANDLER': 'JSON' },
+        \ 'env': { g:syntastic_perl6_enviroment_variable: 'JSON' },
         \ 'defaults': { 'bufnr': bufnr(''), 'type': 'E' },
         \ 'returns': [0, 1],
         \ 'preprocess': 'perl6',

--- a/syntax_checkers/perl6/perl6.vim
+++ b/syntax_checkers/perl6/perl6.vim
@@ -25,13 +25,6 @@
 " Reference:
 "
 " - https://docs.perl6.org/programs/00-running
-"
-" If the Rakudo compiler version is before version 2018.08:
-"
-"   let g:syntastic_perl6_enviroment_variable = "RAKUDO_EXCEPTIONS_HANDLER"
-"
-" Reference:
-"
 " - https://docs.perl6.org/programs/03-environment-variables.html
 "
 
@@ -41,7 +34,7 @@ endif
 let g:loaded_syntastic_perl6_perl6_checker = 1
 
 if !exists('g:syntastic_perl6_enviroment_variable')
-    let g:syntastic_perl6_enviroment_variable="PERL6_EXCEPTIONS_HANDLER"
+   let g:syntastic_perl6_enviroment_variable = "PERL6_EXCEPTIONS_HANDLER"
 endif
 
 if !exists('g:syntastic_perl6_lib_path')


### PR DESCRIPTION
In the new version of Perl 6, the environment variable `RAKUDO_EXCEPTIONS_HANDLER` is no longer used. The variable `PERL6_EXCEPTIONS_HANDLER` is used now to make the `perl6 -c` output as `JSON` format.

This commit updates the default environment variable to `PERL6_EXCEPTIONS_HANDLER`. User can change this variable to the older version by:
> `g:syntastic_perl6_enviroment_variable = "RAKUDO_EXCEPTIONS_HANDLER"`.

Reference:  <https://docs.perl6.org/programs/03-environment-variables#___top>