### PR TITLE
Adds warnings support for the solidity/solc checker.

### DIFF
--- a/syntax_checkers/solidity/solc.vim
+++ b/syntax_checkers/solidity/solc.vim
@@ -21,7 +21,7 @@ set cpo&vim
 function! SyntaxCheckers_solidity_solc_GetLocList() dict
     let makeprg = self.makeprgBuild({})
 
-    let errorformat = '%f:%l:%c: %trror: %m'
+    let errorformat = '%f:%l:%c: %trror: %m,%f:%l:%c: %tarning: %m'
 
     return SyntasticMake({
         \ 'makeprg': makeprg,


### PR DESCRIPTION
Warnings such as:
```
SimpleStorage.sol:7:16: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
  function set(uint x) public {...
```
are not detected by the solc.vim checker. This adds a new format to the local errorformat variable so that they are.