### PR TITLE
Loclist follow

### DIFF
--- a/doc/syntastic.txt
+++ b/doc/syntastic.txt
@@ -499,6 +499,14 @@ When set to 3 the error window will be automatically opened when errors are
 detected, but not closed automatically. >
     let g:syntastic_auto_loc_list = 3
 <
+                                                 *'syntastic_loc_list_follow'*
+Type: integer
+Default: 0
+Use this option to enable automatic updating of the selected location list
+item based on the current cursor position. The nearest item with be selected.
+>
+    let g:syntastic_loc_list_follow = 1
+<
                                                  *'syntastic_loc_list_height'*
 Type: integer
 Default: 10

--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -101,6 +101,7 @@ let g:_SYNTASTIC_DEFAULTS = {
         \ 'id_checkers':              1,
         \ 'ignore_extensions':        '\c\v^([gx]?z|lzma|bz2)$',
         \ 'ignore_files':             [],
+        \ 'loc_list_follow':          0,
         \ 'loc_list_height':          10,
         \ 'nested_autocommands':      0,
         \ 'quiet_messages':           {},
@@ -436,6 +437,13 @@ function! s:UpdateErrors(buf, auto_invoked, checker_names) abort " {{{2
         endif
     endif
     " }}}3
+
+    " loclist follow nearest {{{3
+    if syntastic#util#var('loc_list_follow')
+        autocmd CursorMoved <buffer> call g:SyntasticLoclist.nearest()
+    endif
+    " }}}3
+
 
     call s:notifiers.refresh(loclist)
 endfunction " }}}2

--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -438,9 +438,9 @@ function! s:UpdateErrors(buf, auto_invoked, checker_names) abort " {{{2
     endif
     " }}}3
 
-    " loclist follow nearest {{{3
+    " enable loclist follow {{{3
     if syntastic#util#var('loc_list_follow')
-        autocmd CursorMoved <buffer> call g:SyntasticLoclist.nearest()
+        let b:syntastic_loclist_pos = 1
     endif
     " }}}3
 

--- a/plugin/syntastic/cursor.vim
+++ b/plugin/syntastic/cursor.vim
@@ -34,7 +34,6 @@ function! g:SyntasticCursorNotifier.reset(loclist) abort " {{{2
     unlet! b:syntastic_private_messages
     let b:syntastic_private_line = -1
     unlet! b:syntastic_loclist_pos
-    unlet! b:syntastic_loclist_line
 endfunction " }}}2
 " @vimlint(EVL103, 0, a:loclist)
 
@@ -46,6 +45,11 @@ function! SyntasticRefreshCursor() abort " {{{2
     if !exists('b:syntastic_private_messages') || empty(b:syntastic_private_messages)
         " file not checked
         return
+    endif
+
+    " precedence to avoid further short-circuits
+    if exists('b:syntastic_loclist_pos')
+        call g:SyntasticLoclist.nearest()
     endif
 
     if !exists('b:syntastic_private_line')
@@ -88,10 +92,6 @@ function! SyntasticRefreshCursor() abort " {{{2
         else
             echo
         endif
-    endif
-
-    if exists('b:syntastic_loclist_pos')
-        call g:SyntasticLoclist.nearest()
     endif
 endfunction " }}}2
 

--- a/plugin/syntastic/cursor.vim
+++ b/plugin/syntastic/cursor.vim
@@ -33,6 +33,8 @@ function! g:SyntasticCursorNotifier.reset(loclist) abort " {{{2
     autocmd! syntastic CursorMoved
     unlet! b:syntastic_private_messages
     let b:syntastic_private_line = -1
+    unlet! b:syntastic_loclist_pos
+    unlet! b:syntastic_loclist_line
 endfunction " }}}2
 " @vimlint(EVL103, 0, a:loclist)
 
@@ -86,6 +88,10 @@ function! SyntasticRefreshCursor() abort " {{{2
         else
             echo
         endif
+    endif
+
+    if exists('b:syntastic_loclist_pos')
+        call g:SyntasticLoclist.nearest()
     endif
 endfunction " }}}2
 

--- a/plugin/syntastic/loclist.vim
+++ b/plugin/syntastic/loclist.vim
@@ -371,6 +371,8 @@ function! g:SyntasticLoclist.nearest() abort " {{{2
         while idx + 1 < l_ll && get(ll, idx + 1).lnum == ln
             if abs(get(ll, idx + 1).col - col) < abs(get(ll, idx).col - col)
                 let idx += 1
+            elseif col > get(ll, idx + 1).col
+                let idx += 1
             else
                 break
             endif

--- a/plugin/syntastic/loclist.vim
+++ b/plugin/syntastic/loclist.vim
@@ -340,6 +340,46 @@ function! g:SyntasticLoclist.show() abort " {{{2
     endif
 endfunction " }}}2
 
+" jump to nearest item in the location list based on current line
+function! g:SyntasticLoclist.nearest() abort " {{{2
+    " short-circuits
+    let ll = getloclist('')
+    let l_ll = len(ll)
+    if l_ll == 0
+        return
+    endif
+    let pos = getpos('.')
+    let ln = pos[1]
+    if exists("b:syntastic_loclist_line") && b:syntastic_loclist_line == ln
+        return
+    endif
+    let b:syntastic_loclist_line = ln
+
+    " determine current nearest, assume last as optimum start, correct
+    " and account for multiple items per line
+    let idx = 0
+    if exists("b:syntastic_loclist_pos")
+        let idx = min([l_ll - 1, b:syntastic_loclist_pos - 1])
+    endif
+    while get(ll, idx).lnum >= ln && idx > 0
+        let idx -= 1
+    endwhile
+    while get(ll, idx).lnum < ln && idx < l_ll - 1
+        let idx += 1
+    endwhile
+    let idx_next = ((abs(get(ll, max([idx - 1, 0])).lnum - ln) <= abs(get(ll,idx).lnum - ln)) ? max([idx - 1, 0]) : idx)
+
+    " set
+    if idx_next < 0 || (exists("b:syntastic_loclist_pos") && b:syntastic_loclist_pos == idx_next + 1)
+        return
+    endif
+    let b:syntastic_loclist_pos = idx_next + 1
+    exe "ll " . b:syntastic_loclist_pos
+
+    " cleanup
+    call setpos(".", pos)
+endfunction " }}}2
+
 " }}}1
 
 " Public functions {{{1


### PR DESCRIPTION
For your consideration. 

As per the first commit message..

-adds 'SyntasticLoclist.nearest()' which sets the location list
position to the item nearest the current buffer's cursor position. use
of the 'CursorMoved' hook allowing this to be used to 'sync' your
cursor with the location list
-enabled / disabled via 'g:syntastic_loc_list_follow' int

Notes:
1. Touches vimscript only.
2. I've had a simpler version of this working a while now, the latter tweaks/commits around interline movement are new, but appear to be working well.
3. Please be aware my vimscript foo isn't great so elementary vimscript faux-pas should be looked for!
4. The attempt at integration feels a little flaky to me too. Although I believe I followed an existing pattern, using a buffer variable as 'the switch' doesn't seem ideal, and also finding I had to move the hook in 'SyntasticRefreshCursor' to avoid short-circuits for 'private line' functionality felt hairy.
5. There may be a better (built-in) mechanism to arrive at the current/last item too (e.g. it's surely calculated somewhere given it's displayed in the cmd window (albeit only when the cursor is actually on the item)) ..but alas, the functionality I wanted, based on my own preference, was 'whatever's nearest', full stop, and that's what's implemented.
6. I think the use of the buffer var storing last position, in order to quickly get one to 'usually within the near vicinity of' the correct line on each iteration is a good enough approach to scale with silly large list sets - I see no lag at all.. ..but then maybe my setup is simplistic (few plugins) compared to others and thus this might require consideration. As noted in the last commit, a short-circuit was necessarily removed to get the interline aspect working ..so maybe that could be optional.

My sincere thanks for this plugin, it's just fantastic.