### PR TITLE
Add a new Go linter: gopls

### DIFF
--- a/doc/syntastic-checkers.txt
+++ b/doc/syntastic-checkers.txt
@@ -2516,8 +2516,9 @@ The following checkers are available for Go (filetype "go"):
     3. GolangCI-Lint............|syntastic-go-golangci_lint|
     4. Golint...................|syntastic-go-golint|
     5. Go Meta Linter...........|syntastic-go-gometalinter|
-    6. gotype...................|syntastic-go-gotype|
-    7. vet......................|syntastic-go-govet|
+    6. gopls....................|syntastic-go-gopls|
+    7. gotype...................|syntastic-go-gotype|
+    8. vet......................|syntastic-go-govet|
 
 ------------------------------------------------------------------------------
 1. go                                                        *syntastic-go-go*
@@ -2613,7 +2614,25 @@ This checker is initialised using the "makeprgBuild()" function and thus it
 accepts the standard options described at |syntastic-config-makeprg|.
 
 ------------------------------------------------------------------------------
-6. gotype                                                *syntastic-go-gotype*
+6. gopls                                                  *syntastic-go-gopls*
+
+Name:       gopls
+Maintainer: Jean-Philippe Guérard <jean-philippe.guerard@tigreraye.org>
+
+gopls (pronounced: "go please") is an implementation of the Language Server
+Protocol (LSP) server for Go. It can be used as a standalone linter.
+See the Go wiki for details:
+
+    https://github.com/golang/go/wiki/gopls
+
+Note~
+
+Initial releases of gopls did not allow use as a standalone linter. This
+checker will only work with releases of gopls that allow the use of
+the "version" and "check" commands.
+
+------------------------------------------------------------------------------
+7. gotype                                                *syntastic-go-gotype*
 
 Name:        gotype
 Maintainer:  luz <ne.tetewi@gmail.com>
@@ -2623,7 +2642,7 @@ See the tool's documentation for details:
     https://godoc.org/golang.org/x/tools/cmd/gotype
 
 ------------------------------------------------------------------------------
-7. vet                                                    *syntastic-go-govet*
+8. vet                                                    *syntastic-go-govet*
 
 Name:        govet
 Maintainer:  Kamil Kisiel <kamil@kamilkisiel.net>

--- a/syntax_checkers/go/gopls.vim
+++ b/syntax_checkers/go/gopls.vim
@@ -1,0 +1,53 @@
+"============================================================================
+"File:        gopls.vim
+"Description: Check go syntax using 'gopls check'
+"Maintainer:  Jean-Philippe Guérard <jean dash philippe dot guerard at tigreraye dot org>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"============================================================================
+
+if exists('g:loaded_syntastic_go_gopls_checker')
+    finish
+endif
+let g:loaded_syntastic_go_gopls_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_go_gopls_IsAvailable() dict
+    if !executable(self.getExec())
+        return 0
+    endif
+    " Older version of gopls only understand 'gopls serve', but not 'gopls
+    " version' or 'gopls check'
+    call syntastic#util#system(self.getExecEscaped() . ' version')
+    return v:shell_error == 0
+endfunction
+
+function! SyntaxCheckers_go_gopls_GetLocList() dict
+    let makeprg = self.makeprgBuild({ 'args_before':  'check' })
+
+    let errorformat =
+        \ '%f:%l:%c: %m,' .
+        \ '%f:%l:%c-%\\d%\\+: %m,' .
+        \ '%-G%.%#'
+
+    return SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat,
+        \ 'defaults': {'type': 'e'},
+        \ 'subtype': 'Style' })
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'go',
+    \ 'name': 'gopls',
+    \ 'exec': 'gopls' })
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set sw=4 sts=4 et fdm=marker:


### PR DESCRIPTION
gopls is a new Language Server Protocol implementation for Go. With recent releases, it can also be used as a standalone linter.

This new checker uses gopls to check Go programs.
