### PR TITLE
Checker shellcheck: check external sources by default.

### DIFF
--- a/syntax_checkers/sh/shellcheck.vim
+++ b/syntax_checkers/sh/shellcheck.vim
@@ -15,7 +15,7 @@ function! SyntaxCheckers_sh_shellcheck_GetLocList() dict " {{{1
     let buf = bufnr('')
     let makeprg = self.makeprgBuild({
         \ 'args': s:GetShell(buf),
-        \ 'args_after': '-f gcc' })
+        \ 'args_after': '-f gcc -x' })
 
     let errorformat =
         \ '%f:%l:%c: %trror: %m,' .


### PR DESCRIPTION
       -x, --external-sources
              Follow 'source' statements even when the file is not specified as input.  By default, shellcheck will only follow files specified on the command line (plus /dev/null).  This option allows following any file  the script may source.
