### PR TITLE
Update possible mypy return codes, update documentation

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -21,7 +21,8 @@
 1. [Introduction](#introduction)  
 2. [Installation](#installation)  
 2.1. [Requirements](#requirements)  
-2.2. [Installing syntastic with Pathogen](#installpathogen)  
+2.2. [Installing syntastic with Pathogen](#installpathogen)
+2.3. [Installing syntatic with vim8 packages](#installvim8)  
 3. [Recommended settings](#settings)  
 4. [FAQ](#faq)  
 4.1. [I installed syntastic but it isn't reporting any errors...](#faqinfo)  
@@ -170,6 +171,21 @@ following:
 2. Added the `execute pathogen#infect()` line to your `~/.vimrc` file
 3. Did the `git clone` of syntastic inside `~/.vim/bundle`
 4. Have permissions to access all of these directories.
+
+<a name="installvim8"></a>
+### 2.2.3\. Installing syntatic with vim8 packages
+ 
+```
+git clone https://github.com/vim-syntastic/syntastic.git ~/.vim/pack/plugins/start/syntastic.vim
+```
+
+After launching vim, run 
+```
+:helptags ~/.vim/pack/plugins/start/syntastic.vim/doc/
+```
+
+to generate the manual (`:help syntastic`) 
+
 
 <a name="settings"></a>
 

--- a/README.markdown
+++ b/README.markdown
@@ -21,8 +21,8 @@
 1. [Introduction](#introduction)  
 2. [Installation](#installation)  
 2.1. [Requirements](#requirements)  
-2.2. [Installing syntastic with Pathogen](#installpathogen)<br />
-2.3. [Installing syntastic with vim8 packages](#installvim8) 
+2.2. [Installing syntastic with Pathogen](#installpathogen)  
+2.3. [Installing syntastic with vim8 packages](#installvim8)  
 3. [Recommended settings](#settings)  
 4. [FAQ](#faq)  
 4.1. [I installed syntastic but it isn't reporting any errors...](#faqinfo)  

--- a/README.markdown
+++ b/README.markdown
@@ -22,7 +22,7 @@
 2. [Installation](#installation)  
 2.1. [Requirements](#requirements)  
 2.2. [Installing syntastic with Pathogen](#installpathogen)  
-2.3. [Installing syntastic with vim8 packages](#installvim8)  
+2.3. [Installing syntastic with vim packages](#installvim)  
 3. [Recommended settings](#settings)  
 4. [FAQ](#faq)  
 4.1. [I installed syntastic but it isn't reporting any errors...](#faqinfo)  
@@ -172,7 +172,7 @@ following:
 3. Did the `git clone` of syntastic inside `~/.vim/bundle`
 4. Have permissions to access all of these directories.
 
-<a name="installvim8"></a>
+<a name="installvim"></a>
 
 ### 2.3\. Installing syntatic with vim packages
  
@@ -180,11 +180,10 @@ following:
 git clone https://github.com/vim-syntastic/syntastic.git ~/.vim/pack/plugins/start/syntastic.vim
 ```
 
-After launching vim, run 
+After installing, launch vim and run
 ```
 :helptags ~/.vim/pack/plugins/start/syntastic.vim/doc/
 ```
-
 to generate the manual (`:help syntastic`) 
 
 

--- a/README.markdown
+++ b/README.markdown
@@ -21,8 +21,8 @@
 1. [Introduction](#introduction)  
 2. [Installation](#installation)  
 2.1. [Requirements](#requirements)  
-2.2. [Installing syntastic with Pathogen](#installpathogen)
-2.3. [Installing syntatic with vim8 packages](#installvim8)  
+2.2. [Installing syntastic with Pathogen](#installpathogen)<br />
+2.3. [Installing syntastic with vim8 packages](#installvim8) 
 3. [Recommended settings](#settings)  
 4. [FAQ](#faq)  
 4.1. [I installed syntastic but it isn't reporting any errors...](#faqinfo)  
@@ -173,7 +173,8 @@ following:
 4. Have permissions to access all of these directories.
 
 <a name="installvim8"></a>
-### 2.2.3\. Installing syntatic with vim8 packages
+
+### 2.3\. Installing syntatic with vim packages
  
 ```
 git clone https://github.com/vim-syntastic/syntastic.git ~/.vim/pack/plugins/start/syntastic.vim

--- a/syntax_checkers/python/mypy.vim
+++ b/syntax_checkers/python/mypy.vim
@@ -32,7 +32,7 @@ function! SyntaxCheckers_python_mypy_GetLocList() dict
     return SyntasticMake({
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat,
-        \ 'returns': [0, 1],
+        \ 'returns': [0, 1, 2],
         \ 'preprocess': 'mypy' })
 endfunction
 


### PR DESCRIPTION
Added an extra section to the documentation which demonstrates how one
can install syntastic from git using vim packages.

mypy will return 2 as a potential error code in cases of improperly
formatted python syntax. 

For example:
```python
#!/usr/bin/env python
a =
```
will provide a return code of 2 for invalid syntax. 

This updates the mypy configuration to accept this return code.