### PR TITLE
Fix issues in Objective-C++ gcc checker

### DIFF
--- a/syntax_checkers/objcpp/gcc.vim
+++ b/syntax_checkers/objcpp/gcc.vim
@@ -16,15 +16,15 @@ endif
 let g:loaded_syntastic_objcpp_gcc_checker = 1
 
 if !exists('g:syntastic_objcpp_compiler_options')
-    let g:syntastic_objcpp_compiler_options = '-std=gnu99'
+    let g:syntastic_objcpp_compiler_options = '-std=gnu++14'
 endif
 
 let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_objcpp_gcc_IsAvailable() dict
-    if !exists('g:syntastic_c_compiler')
-        let g:syntastic_objcpp_compiler = executable(self.getExec()) ? self.getExec() : 'clang'
+    if !exists('g:syntastic_objcpp_compiler')
+        let g:syntastic_objcpp_compiler = executable(self.getExec()) ? self.getExec() : 'clang++'
     endif
     call self.log('g:syntastic_objcpp_compiler =', g:syntastic_objcpp_compiler)
     return executable(expand(g:syntastic_objcpp_compiler, 1))
@@ -51,7 +51,8 @@ endfunction
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({
     \ 'filetype': 'objcpp',
-    \ 'name': 'gcc' })
+    \ 'name': 'gcc',
+    \ 'exec': 'g++' })
 
 let &cpo = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
* `-std=gnu99` has been changed to `-std=gnu++14` in the default compiler options to reflect the default in the current stable version of Xcode (`-std=gnu99` previously broke the checker)
* `SyntaxCheckers_objcpp_gcc_IsAvailable()` now checks for the existence of the correct global when deciding whether to use the default compiler (previously checked for the C compiler)
* Default compiler executables have been changed to reflect that Objective-C++ is a flavor/dialect of C++, not C