### PR TITLE
Add cpplint checker support for C

### DIFF
--- a/doc/syntastic-checkers.txt
+++ b/doc/syntastic-checkers.txt
@@ -535,13 +535,14 @@ The following checkers are available for C (filetype "c"):
     4. Clang-Tidy...............|syntastic-c-clang_tidy|
     5. Cppcheck.................|syntastic-c-cppcheck|
     6. cppclean.................|syntastic-c-cppclean|
-    7. Flawfinder...............|syntastic-c-flawfinder|
-    8. GCC......................|syntastic-c-gcc|
-    9. make.....................|syntastic-c-make|
-    10. OClint..................|syntastic-c-oclint|
-    11. PC-Lint.................|syntastic-c-pc_lint|
-    12. Sparse..................|syntastic-c-sparse|
-    13. Splint..................|syntastic-c-splint|
+    7. Cpplint..................|syntastic-c-cpplint|
+    8. Flawfinder...............|syntastic-c-flawfinder|
+    9. GCC......................|syntastic-c-gcc|
+    10. make....................|syntastic-c-make|
+    11. OClint..................|syntastic-c-oclint|
+    12. PC-Lint.................|syntastic-c-pc_lint|
+    13. Sparse..................|syntastic-c-sparse|
+    14. Splint..................|syntastic-c-splint|
 
 ------------------------------------------------------------------------------
 1. AVR-GCC                                                *syntastic-c-avrgcc*
@@ -723,7 +724,43 @@ accepts the standard options described at |syntastic-config-makeprg|.
 See also: |syntastic-cpp-cppclean|.
 
 ------------------------------------------------------------------------------
-7. Flawfinder                                         *syntastic-c-flawfinder*
+7. Cpplint                                               *syntastic-c-cpplint*
+
+Name:        cpplint
+Maintainer:  Laurent Cheylus <foxy@free.fr>
+
+For details about "Cpplint" see the project's page:
+
+    https://github.com/google/styleguide
+
+Checker options~
+
+This checker is initialised using the "makeprgBuild()" function and thus it
+accepts the standard options described at |syntastic-config-makeprg|.
+
+Additionally:
+
+                                             *'g:syntastic_c_cpplint_thres'*
+Type: integer
+Default: 5
+Error threshold. Policy violations with a severity above this value are
+highlighted as errors, the others are considered warnings by syntastic.
+
+                                              *'g:syntastic_c_cpplint_args'*
+Type: string
+Default: "--verbose=3 --filter=-readability/casting"
+Command line options to pass to "Cpplint"
+
+Note~
+
+By default syntastic expects the "cpplint" script to be named "cpplint.py".
+However, if your "cpplint" was installed with "pip", the script's name is
+"cpplint", and you need to set 'g:syntastic_c_cpplint_exec' accordingly:
+>
+    let g:syntastic_c_cpplint_exec = "cpplint"
+<
+------------------------------------------------------------------------------
+8. Flawfinder                                         *syntastic-c-flawfinder*
 
 Name:        flawfinder
 Maintainer:  LCD 47 <lcd047@gmail.com>
@@ -749,7 +786,7 @@ highlighted as errors, the others are considered warnings by syntastic.
 See also: |syntastic-cpp-flawfinder|.
 
 ------------------------------------------------------------------------------
-8. GCC                                                       *syntastic-c-gcc*
+9. GCC                                                       *syntastic-c-gcc*
 
 Name:        gcc
 Maintainer:  Gregor Uhlenheuer <kongo2002@gmail.com>
@@ -846,7 +883,7 @@ executable.
 See also: |syntastic-cpp-gcc|.
 
 ------------------------------------------------------------------------------
-9. make                                                     *syntastic-c-make*
+10. make                                                     *syntastic-c-make*
 
 Name:        make
 Maintainer:  Gregor Uhlenheuer <kongo2002@gmail.com>
@@ -857,7 +894,7 @@ This checker is initialised using the "makeprgBuild()" function and thus it
 accepts the standard options described at |syntastic-config-makeprg|.
 
 ------------------------------------------------------------------------------
-10. OClint                                                *syntastic-c-oclint*
+11. OClint                                                *syntastic-c-oclint*
 
 Name:        oclint
 Maintainer:  "UnCO" Lin <undercooled@lavabit.com>
@@ -896,7 +933,7 @@ Config files pointed to by 'g:syntastic_oclint_config_file' are then ignored.
 See also: |syntastic-cpp-oclint|.
 
 ------------------------------------------------------------------------------
-11. PC-Lint                                              *syntastic-c-pc_lint*
+12. PC-Lint                                              *syntastic-c-pc_lint*
 
 Name:        pc_lint
 Maintainer:  Steve Bragg <steve@empresseffects.com>
@@ -923,7 +960,7 @@ current directory and in parent directories; first such file found is used.
 See also: |syntastic-cpp-pc_lint|.
 
 ------------------------------------------------------------------------------
-12. Sparse                                                *syntastic-c-sparse*
+13. Sparse                                                *syntastic-c-sparse*
 
 Name:        sparse
 Maintainer:  Daniel Walker <dwalker@fifo99.com>
@@ -955,7 +992,7 @@ your vimrc: >
 This allows "Sparse" to read "GCC"'s private include files.
 
 ------------------------------------------------------------------------------
-13. Splint                                                *syntastic-c-splint*
+14. Splint                                                *syntastic-c-splint*
 
 Name:        splint
 Maintainer:  LCD 47 <lcd047@gmail.com>
@@ -1192,7 +1229,7 @@ Maintainer:  LCD 47 <lcd047@gmail.com>
 
 For details about "Cpplint" see the project's page:
 
-    https://code.google.com/p/google-styleguide/
+    https://github.com/google/styleguide
 
 Checker options~
 
@@ -8209,6 +8246,7 @@ syntastic-specific configuration files:
         ClangCheck (|syntastic-c-clang_check|)
         Clang-Tidy (|syntastic-c-clang_tidy|)
         Cppcheck (|syntastic-c-cppcheck|)
+        Cpplint (|syntastic-c-cpplint|)
         GCC (|syntastic-c-gcc|)
         OCLint (|syntastic-c-oclint|)
         Sparse (|syntastic-c-sparse|)

--- a/syntax_checkers/c/cpplint.vim
+++ b/syntax_checkers/c/cpplint.vim
@@ -1,0 +1,52 @@
+"============================================================================
+"File:        cpplint.vim
+"Description: Syntax checking plugin for syntastic
+"Maintainer:  Laurent Cheylus <foxy@free.fr>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"
+"============================================================================
+
+if exists('g:loaded_syntastic_c_cpplint_checker')
+    finish
+endif
+let g:loaded_syntastic_c_cpplint_checker = 1
+
+if !exists('g:syntastic_c_cpplint_thres')
+    let g:syntastic_c_cpplint_thres = 5
+endif
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_c_cpplint_GetLocList() dict
+    let makeprg = self.makeprgBuild({ 'args': '--verbose=3 --filter=-readability/casting' })
+
+    let errorformat = '%A%f:%l:  %m [%t],%-G%.%#'
+
+    let loclist = SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat,
+        \ 'subtype': 'Style',
+        \ 'returns': [0, 1] })
+
+    " change error types according to the prescribed threshold
+    for e in loclist
+        let e['type'] = e['type'] < g:syntastic_c_cpplint_thres ? 'W' : 'E'
+    endfor
+
+    return loclist
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'c',
+    \ 'name': 'cpplint',
+    \ 'exec': 'cpplint.py'})
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set sw=4 sts=4 et fdm=marker:


### PR DESCRIPTION
- add cpplint.vim in syntax_checkers/c (copied/modified from syntax_checkers/cpp/cpplint.vim)
- Fix URL for Google Cpplint project in doc/syntastic-checkers.txt
- Add doc for Cpplint as checker for C