### PR TITLE
add variable g:syntastic_javascript_eslint_command for checker javasc…

### DIFF
--- a/syntax_checkers/javascript/eslint.vim
+++ b/syntax_checkers/javascript/eslint.vim
@@ -22,6 +22,10 @@ if !exists('g:syntastic_javascript_eslint_generic')
     let g:syntastic_javascript_eslint_generic = 0
 endif
 
+if !exists( 'g:syntastic_javascript_eslint_command' )
+    let g:syntastic_javascript_eslint_command = ''
+endif
+
 let s:save_cpo = &cpo
 set cpo&vim
 
@@ -42,7 +46,11 @@ function! SyntaxCheckers_javascript_eslint_GetLocList() dict
             \ "'--config ' . syntastic#util#shexpand(OLD_VAR)")
     endif
 
-    let makeprg = self.makeprgBuild({ 'args_before': (g:syntastic_javascript_eslint_generic ? '' : '-f compact') })
+    if g:syntastic_javascript_eslint_command isnot ''
+        let makeprg = printf( g:syntastic_javascript_eslint_command, syntastic#util#shexpand( '%' ) )
+    else
+        let makeprg = self.makeprgBuild({ 'args_before': (g:syntastic_javascript_eslint_generic ? '' : '-f compact') })
+    endif
 
     let errorformat =
         \ '%E%f: line %l\, col %c\, Error - %m,' .


### PR DESCRIPTION
- add variable `g:syntastic_javascript_eslint_command` to support passing a whole command for `eslint` checker, and the editing file name can be interpolated into the command by using `printf` function.

No existing feature has been changed.

I added this feature because sometimes it needs a more complex way than just running `eslint` command. 

For example:

While using `yarn2`, there isn't a simple way to config the command, with current feature, it should be configured like so:

```
let b:syntastic_typescript_eslint_exec = 'yarn'
let b:syntastic_typescript_eslint_args = [ 'eslint', '-f', 'compact' ]
```

But using `g:syntastic_javascript_eslint_command` option, it'll be more easier:

```
let g:syntastic_javascript_eslint_command = 'yarn eslint -f compact %s'
```

And while using `eslint_d` with `netcat` command, it's even more complex:

```
let g:syntastic_javascript_eslint_command = 'echo `cat ~/.eslint_d | cut -d" " -f2` $PWD -f compact %s | nc localhost `cat ~/.eslint_d | cut -d" " -f1`'
```
