### PR TITLE
Fix Erlang checker for test files with no test cfg

### DIFF
--- a/syntax_checkers/erlang/erlang_check_file.erl
+++ b/syntax_checkers/erlang/erlang_check_file.erl
@@ -61,7 +61,15 @@ which_build_tool(Dir, Profile) ->
     end.
 
 rebar_file(Dir, normal) -> filename:join(Dir, "rebar.config");
-rebar_file(Dir, test)   -> filename:join(Dir, "rebar.test.config").
+rebar_file(Dir, test)   ->
+    TestConfig = filename:join(Dir, "rebar.test.config"),
+    case filelib:is_file(TestConfig) of
+        true ->
+            TestConfig;
+        false ->
+            %% If we can't find "rebar.test.config" try falling back:
+            rebar_file(Dir, normal)
+    end.
 
 erlangmk_file(Dir) -> filename:join(Dir, "erlang.mk").
 


### PR DESCRIPTION
If we're editing a file in the "test" directory, the syntax checker
assumes we should use the 'test' profile and attempts to read from
"rebar.test.config" instead of "rebar.config". However, it is common to
have Erlang projects with tests that don't necessarily use a separate
"rebar.test.config" file, and in those types of projects the syntax
checker will break. This patch handles this case by falling back to
using "rebar.config" for tests if a separate "rebar.test.config" file is
not found.