### PR TITLE
Checker go/golangci_lint: add cwd parameters and fix error format for some linters

### DIFF
--- a/syntax_checkers/go/golangci_lint.vim
+++ b/syntax_checkers/go/golangci_lint.vim
@@ -19,15 +19,21 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_go_golangci_lint_GetLocList() dict
-    let makeprg = self.makeprgBuild({ 'args_before':  'run' })
+    let buf = bufnr('')
+
+    let makeprg = self.makeprgBuild({
+        \ 'args_before': 'run',
+        \ 'fname': '.' })
 
     let errorformat =
         \ '%f:%l:%c: %m,' .
+        \ '%f:%l: %m,' .
         \ '%-G%.%#'
 
     return SyntasticMake({
         \ 'makeprg': makeprg,
         \ 'errorformat': errorformat,
+        \ 'cwd': fnamemodify(bufname(buf), ':p:h'),
         \ 'defaults': {'type': 'e'},
         \ 'subtype': 'Style' })
 endfunction


### PR DESCRIPTION
Some linters("typecheck", "lll") need pacakge path to work.
These linters were supported by golangci-lint, however can't work
correctly in Syntastic with lacking of package path.
You can check these supported linters list in https://golangci-lint.run/usage/configuration/

Morever, some linters ("lll", "goimports" etc) wouldn't pass column num to stdout. So, I add new errorformat pattern to recognize error messages from these linters.