### PR TITLE
Do not override options cppcheck arguments from config file with cppcheck_args

### DIFF
--- a/doc/syntastic-checkers.txt
+++ b/doc/syntastic-checkers.txt
@@ -693,8 +693,8 @@ Additionally:
                                           *'g:syntastic_cppcheck_config_file'*
 Type: string
 Default: unset
-File containing compilation flags (such as defines or include directories),
-one option per line (cf. |syntastic-config-files|).
+File containing additional compilation flags (such as defines or include
+directories), one option per line (cf. |syntastic-config-files|).
 
 See also: |syntastic-cpp-cppcheck|.
 

--- a/syntax_checkers/c/cppcheck.vim
+++ b/syntax_checkers/c/cppcheck.vim
@@ -21,7 +21,7 @@ function! SyntaxCheckers_c_cppcheck_GetLocList() dict
     let buf = bufnr('')
 
     let makeprg = self.makeprgBuild({
-        \ 'args': syntastic#c#ReadConfig(syntastic#util#bufVar(buf, 'cppcheck_config_file')),
+        \ 'args_before': syntastic#c#ReadConfig(syntastic#util#bufVar(buf, 'cppcheck_config_file')),
         \ 'args_after': '-q --enable=style' })
 
     let errorformat =


### PR DESCRIPTION
Configuration for _cppcheck_ from a config file configured via `g:syntastic_cppcheck_config_file` was overwritten by content of `g:syntastic_cpp_cppcheck_args`. But for other checkers the options from the configured config file are appended to the call arguments of the checker. With this change the options from the _cppcheck_ config file will also be appended and not be overwritten by any static configuration.

But be aware, that this will change the behavior of the config options for _cppcheck_.