### PR TITLE
Adds explicit buffer number to SyntasticStatuslineFlag.

### DIFF
--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -695,7 +695,11 @@ endfunction " }}}2
 "
 "return '' if no errors are cached for the buffer
 function! SyntasticStatuslineFlag() abort " {{{2
-    return g:SyntasticLoclist.current().getStatuslineFlag()
+    if exists('g:statusline_winid')
+        return g:SyntasticLoclist.current(winbufnr(g:statusline_winid)).getStatuslineFlag()
+    else
+        return g:SyntasticLoclist.current().getStatuslineFlag()
+    endif
 endfunction " }}}2
 
 " }}}1


### PR DESCRIPTION
When using splits in vim, it may happen that the statusline of
an inactive window gets redrawn. In that case, the 'current()'
buffer is no longer right. This fix finds the proper buffer
number to use, by using the g:statusline_winid when it exists.
In other cases, fallback to an empty current() call.