### PR TITLE
Add python3 checker

### DIFF
--- a/syntax_checkers/python/codec3.py
+++ b/syntax_checkers/python/codec3.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+from sys import argv, exit
+
+import codecs
+import re
+import os
+
+
+if len(argv) != 2:
+    exit(1)
+
+try:
+    with open(argv[1]) as fle:
+        text = fle.readlines()
+
+    if text:
+        match = re.match(r"#\s*coding\s*:\s*(?P<coding>\w+)", text[0])
+        if match:
+            text = codecs.lookup(match.groupdict()["coding"]).incrementaldecoder().decode(
+                ''.join(text).encode('utf-8')).encode('utf-8')
+
+    if isinstance(text, list):
+        text = ''.join(text).encode('utf-8')
+
+    compile(text, argv[1], 'exec', 0, 1)
+except SyntaxError as err:
+    print('%s:%s:%s: %s' % (err.filename, err.lineno, err.offset, err.msg))
+except Exception as err:
+    print('%s:%s:%s: %s' % (os.path.abspath(argv[1]), 1, 0, err))

--- a/syntax_checkers/python/compile3.py
+++ b/syntax_checkers/python/compile3.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+from sys import argv, exit
+
+
+if len(argv) != 2:
+    exit(1)
+
+try:
+    compile(open(argv[1]).read(), argv[1], 'exec', 0, 1)
+except SyntaxError as err:
+    print('%s:%s:%s: %s' % (err.filename, err.lineno, err.offset, err.msg))

--- a/syntax_checkers/python/python3.vim
+++ b/syntax_checkers/python/python3.vim
@@ -1,0 +1,57 @@
+"============================================================================
+"File:        python3.vim
+"Description: Syntax checking plugin for syntastic
+"Maintainer:  LCD 47 <lcd047 at gmail dot com>
+"License:     This program is free software. It comes without any warranty,
+"             to the extent permitted by applicable law. You can redistribute
+"             it and/or modify it under the terms of the Do What The Fuck You
+"             Want To Public License, Version 2, as published by Sam Hocevar.
+"             See http://sam.zoy.org/wtfpl/COPYING for more details.
+"
+"============================================================================
+
+if exists('g:loaded_syntastic_python_python3_checker')
+    finish
+endif
+let g:loaded_syntastic_python_python3_checker = 1
+
+if !exists('g:syntastic_python_python3_use_codec')
+    let g:syntastic_python_python3_use_codec = 0
+endif
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+let s:base_path = expand('<sfile>:p:h', 1) . syntastic#util#Slash()
+
+function! SyntaxCheckers_python_python3_IsAvailable() dict
+    if !executable(self.getExec())
+        return 0
+    endif
+    return syntastic#util#versionIsAtLeast(self.getVersion(), [2, 6])
+endfunction
+
+function! SyntaxCheckers_python_python3_GetLocList() dict
+    let compiler = s:base_path . (g:syntastic_python_python3_use_codec ? 'codec3.py' : 'compile3.py')
+    call self.log('using compiler script', compiler)
+    let makeprg = self.makeprgBuild({ 'exe': [self.getExec(), compiler] })
+
+    let errorformat = '%E%f:%l:%c: %m'
+
+    let env = syntastic#util#isRunningWindows() ? {} : { 'TERM': 'dumb' }
+
+    return SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat,
+        \ 'env': env,
+        \ 'returns': [0] })
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'python',
+    \ 'name': 'python3'})
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim: set sw=4 sts=4 et fdm=marker:


### PR DESCRIPTION
What it says on the tin.  This adds an explicit "python3" syntax checker, that explicitly calls "python3" instead of "python," allowing an easy, system-wide workaround for distributions that are still shipping python2 as the default system python for legacy reasons.