### PR TITLE
Checker python/pylint: display message ID

### DIFF
--- a/syntax_checkers/python/pylint.vim
+++ b/syntax_checkers/python/pylint.vim
@@ -50,7 +50,7 @@ endfunction " }}}1
 function! SyntaxCheckers_python_pylint_GetLocList() dict " {{{1
     let makeprg = self.makeprgBuild({
         \ 'args_after': (s:pylint_new ?
-        \       '-f text --msg-template="{path}:{line}:{column}:{C}: [{symbol}] {msg}" -r n' :
+        \       '-f text --msg-template="{path}:{line}:{column}:{C}: [{msg_id}][{symbol}] {msg}" -r n' :
         \       '-f parseable -r n -i y') })
 
     let errorformat =


### PR DESCRIPTION
For the time being, pylint error code (msg_id) are not display in the
statusline and the location window. For instance,

```
  1 test.y|89 col 13 warning| [consider-using-f-string] Formatting a regular string which could be a f-string [python/pylint]
```
It would be great to have the ID of this message so that we can pass it
directly to projects like `plerr`.

This PR add the code next to the 'symbol' (like
consider-using-f-string). As an example:
```
  1 test.y|89 col 13 warning| [C0209][consider-using-f-string] Formatting a regular string which could be a f-string [python/pylint]
```
Regards,