### PR TITLE
Fallback errorformat for ansible_lint

### DIFF
--- a/syntax_checkers/ansible/ansible_lint.vim
+++ b/syntax_checkers/ansible/ansible_lint.vim
@@ -31,7 +31,9 @@ function! SyntaxCheckers_ansible_ansible_lint_GetLocList() dict
     let errorformat =
         \ '%f:%l: [E%n] %m,' .
         \ '%f:%l: [EANSIBLE%n] %m,' .
-        \ '%f:%l: [ANSIBLE%n] %m'
+        \ '%f:%l: [ANSIBLE%n] %m,' .
+        \ '%f:%l:%c %m,' .
+        \ '%f:%l: %m'
 
     let env = syntastic#util#isRunningWindows() ? {} : { 'TERM': 'dumb' }
 


### PR DESCRIPTION
Looks like ansible-lint [changed](https://github.com/ansible-community/ansible-lint/pull/1305/files) output format in 5.0.0.

There is a small workaround for error parser.